### PR TITLE
Filter handling for smaller screens

### DIFF
--- a/components/filters/FilterPicker.tsx
+++ b/components/filters/FilterPicker.tsx
@@ -58,7 +58,7 @@ export default function FilterPicker({
     <>
       <div className="picker">
         <div className="picker__selection">
-          <DataList gap="0rem 3rem">
+          <DataList gap="1rem 3rem">
             <FilterPickerCategory
               category="Focus"
               active={focusActive}
@@ -170,6 +170,14 @@ export default function FilterPicker({
             .picker__list {
               margin-bottom: 0;
               max-height: initial;
+            }
+          }
+          @media screen and (max-width: ${theme.layout.breakPoints.medium}) {
+            .selected-member-count {
+              position: sticky;
+              right: 0rem;
+              width: 100%;
+              margin-top: 1rem;
             }
           }
         `}</style>

--- a/components/filters/FilterPicker.tsx
+++ b/components/filters/FilterPicker.tsx
@@ -174,8 +174,7 @@ export default function FilterPicker({
           }
           @media screen and (max-width: ${theme.layout.breakPoints.medium}) {
             .selected-member-count {
-              position: sticky;
-              right: 0rem;
+              position: static;
               width: 100%;
               margin-top: 1rem;
             }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -206,7 +206,7 @@ export default function HomePage({
   };
 
   const filterSelect = (filterType?: string) => {
-    if (viewAll === true) setViewAll(false);
+    if (viewAll) setViewAll(false);
     const filterMap = {
       focus: focuses,
       industry: industries,
@@ -238,14 +238,14 @@ export default function HomePage({
             />
           )}
           {viewAll ? (
-            <h4
+            <a
               onClick={() => {
                 setFiltersList(focuses);
                 setViewAll(false);
               }}
             >
               View All
-            </h4>
+            </a>
           ) : null}
         </aside>
         <main>{members && <MemberDirectory members={members} />}</main>
@@ -282,7 +282,7 @@ export default function HomePage({
             padding: 0 2rem 1rem;
           }
         }
-        h4 {
+        a {
           margin: 0;
           text-align: right;
           width: 5rem;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -73,7 +73,7 @@ export default function HomePage({
   );
   const [activeFilters, setActiveFilters] = useState<PickerFilter[]>([]);
   const [filtersList, setFiltersList] = useState<PickerFilter[]>(
-    initialState.focuses
+    initialState.focuses.slice(0, 7)
   );
   const [focuses, setFocuses] = useState<PickerFilter[]>(initialState.focuses);
   const [industries, setIndustries] = useState<PickerFilter[]>(
@@ -86,6 +86,7 @@ export default function HomePage({
   const [membersCount, setMembersCount] = useState<number>(
     initialState.members.length
   );
+  const [viewAll, setViewAll] = useState<Boolean>(true);
 
   useEffect(() => {
     const activeFilters = focuses
@@ -205,6 +206,7 @@ export default function HomePage({
   };
 
   const filterSelect = (filterType?: string) => {
+    if (viewAll === true) setViewAll(false);
     const filterMap = {
       focus: focuses,
       industry: industries,
@@ -235,6 +237,16 @@ export default function HomePage({
               selectedMemberCount={membersCount}
             />
           )}
+          {viewAll ? (
+            <h4
+              onClick={() => {
+                setFiltersList(focuses);
+                setViewAll(false);
+              }}
+            >
+              View All
+            </h4>
+          ) : null}
         </aside>
         <main>{members && <MemberDirectory members={members} />}</main>
       </div>
@@ -269,6 +281,13 @@ export default function HomePage({
           aside {
             padding: 0 2rem 1rem;
           }
+        }
+        h4 {
+          margin: 0;
+          text-align: right;
+          width: 5rem;
+          color: ${theme.color.brand.base};
+          cursor: pointer;
         }
         h5 {
           margin: 0;


### PR DESCRIPTION
- Adding a handler for the filter select count on the smaller screens
- Cutting the filter list to 7 and giving the user the option to 'View All' with that control

**Before**
<img width="501" alt="Screen Shot 2022-12-11 at 10 24 41 AM" src="https://user-images.githubusercontent.com/26368729/206921979-0cfae00d-d299-4835-aea4-6cea71a28cff.png">

**After**
<img width="440" alt="Screen Shot 2022-12-11 at 10 22 00 AM" src="https://user-images.githubusercontent.com/26368729/206921990-ef8dc001-1b1a-4bea-b0c1-25fd879d573b.png">
