### PR TITLE
adding script to all pages, oops

### DIFF
--- a/components/Plausible.tsx
+++ b/components/Plausible.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export default function Plausible() {
+  return (
+    <script
+      defer
+      data-domain="hawaiiansintech.org"
+      src="https://plausible.io/js/script.js"
+    />
+  );
+}

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,5 +1,6 @@
 import MetaTags from "@/components/Metatags";
 import Nav from "@/components/Nav";
+import Plausible from "@/components/Plausible";
 import { Title } from "@/components/Title.js";
 import { motion } from "framer-motion";
 import Head from "next/head";
@@ -35,6 +36,7 @@ export default function AboutPage({ pageTitle }) {
   return (
     <>
       <Head>
+        <Plausible />
         <MetaTags title={pageTitle} />
         <title>{pageTitle}</title>
       </Head>

--- a/pages/edit/01-you.tsx
+++ b/pages/edit/01-you.tsx
@@ -4,6 +4,7 @@ import BasicInformationForm from "@/components/intake-form/BasicInformation";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import MetaTags from "@/components/Metatags";
 import Nav from "@/components/Nav";
+import Plausible from "@/components/Plausible";
 import { MemberPublicEditing } from "@/lib/api";
 import { useStorage } from "@/lib/hooks";
 import { FORM_LINKS } from "@/lib/utils";
@@ -60,6 +61,7 @@ export default function JoinStep1({ pageTitle }) {
   return (
     <>
       <Head>
+        <Plausible />
         <MetaTags title={pageTitle} />
         <title>{pageTitle}</title>
       </Head>

--- a/pages/edit/02-work.tsx
+++ b/pages/edit/02-work.tsx
@@ -5,6 +5,7 @@ import WorkExperience, {
 } from "@/components/intake-form/WorkExperience";
 import MetaTags from "@/components/Metatags";
 import Nav from "@/components/Nav";
+import Plausible from "@/components/Plausible";
 import { getFilters, MemberPublicEditing } from "@/lib/api";
 import { FirebaseTablesEnum } from "@/lib/enums";
 import { useStorage } from "@/lib/hooks";
@@ -96,6 +97,7 @@ export default function JoinStep2({ focuses, pageTitle }) {
   return (
     <>
       <Head>
+        <Plausible />
         <MetaTags title={pageTitle} />
         <title>{pageTitle}</title>
       </Head>

--- a/pages/edit/03-company.tsx
+++ b/pages/edit/03-company.tsx
@@ -5,6 +5,7 @@ import CompanyIndustry, {
 } from "@/components/intake-form/CompanyIndustry";
 import MetaTags from "@/components/Metatags";
 import Nav from "@/components/Nav";
+import Plausible from "@/components/Plausible";
 import { getFilters, MemberPublicEditing } from "@/lib/api";
 import { FirebaseTablesEnum } from "@/lib/enums";
 import { useStorage } from "@/lib/hooks";
@@ -93,6 +94,7 @@ export default function JoinStep3({ industries, pageTitle }) {
   return (
     <>
       <Head>
+        <Plausible />
         <MetaTags title={pageTitle} />
         <title>{pageTitle}</title>
       </Head>

--- a/pages/edit/04-contact.tsx
+++ b/pages/edit/04-contact.tsx
@@ -7,6 +7,7 @@ import ProgressBar from "@/components/form/ProgressBar";
 import { Heading, Subheading } from "@/components/Heading";
 import MetaTags from "@/components/Metatags";
 import Nav from "@/components/Nav";
+import Plausible from "@/components/Plausible";
 import Tag from "@/components/Tag";
 import { MemberPublic, MemberPublicEditing } from "@/lib/api";
 import { useStorage } from "@/lib/hooks";
@@ -113,6 +114,7 @@ export default function JoinStep4({ pageTitle }) {
   return (
     <>
       <Head>
+        <Plausible />
         <MetaTags title={pageTitle} />
         <title>{pageTitle}</title>
       </Head>

--- a/pages/edit/index.tsx
+++ b/pages/edit/index.tsx
@@ -2,6 +2,7 @@ import Button, { ButtonSize } from "@/components/Button";
 import { Heading, Subheading } from "@/components/Heading";
 import MetaTags from "@/components/Metatags";
 import Nav from "@/components/Nav";
+import Plausible from "@/components/Plausible";
 import Tag from "@/components/Tag";
 import { MemberPublic } from "@/lib/api";
 import { useStorage } from "@/lib/hooks";
@@ -23,6 +24,7 @@ export default function EditPage({ pageTitle }) {
   return (
     <>
       <Head>
+        <Plausible />
         <MetaTags title={pageTitle} />
         <title>{pageTitle}</title>
       </Head>

--- a/pages/edit/thank-you.tsx
+++ b/pages/edit/thank-you.tsx
@@ -1,6 +1,7 @@
 import Accordion, { AccordionProps } from "@/components/Accordion";
 import HitLogo from "@/components/HitLogo";
 import MetaTags from "@/components/Metatags";
+import Plausible from "@/components/Plausible";
 import Tag from "@/components/Tag";
 import { Subtitle } from "@/components/Title";
 import { CONTACT_METHODS } from "@/lib/contact-methods";
@@ -25,6 +26,7 @@ export default function ThankYou({ pageTitle }) {
   return (
     <>
       <Head>
+        <Plausible />
         <MetaTags title={pageTitle} />
         <title>{pageTitle}</title>
       </Head>

--- a/pages/hackathon.tsx
+++ b/pages/hackathon.tsx
@@ -6,6 +6,7 @@ import ImageExpand from "@/components/ImageExpand";
 import MetaTags from "@/components/Metatags";
 import Nav from "@/components/Nav";
 import NihoShimmer from "@/components/NihoShimmer";
+import Plausible from "@/components/Plausible";
 import SplitSection from "@/components/SplitSection";
 import { Title } from "@/components/Title.js";
 import { motion } from "framer-motion";
@@ -40,6 +41,7 @@ export default function HackathonPage({ pageTitle }) {
   return (
     <>
       <Head>
+        <Plausible />
         <MetaTags
           image="https://hawaiiansintech.org/images/ogimage-hackathon.png"
           description="Our inaugural Hackathon event, in partnership with Purple Maiʻa. Hosted by Native Hawaiians in the technology industry."

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,6 +2,7 @@ import FilterPicker, { PickerFilter } from "@/components/filters/FilterPicker";
 import MemberDirectory, { DirectoryMember } from "@/components/MemberDirectory";
 import MetaTags from "@/components/Metatags";
 import Nav from "@/components/Nav";
+import Plausible from "@/components/Plausible";
 import { Title } from "@/components/Title.js";
 import {
   DocumentData,
@@ -240,13 +241,9 @@ export default function HomePage({
   return (
     <>
       <Head>
+        <Plausible />
         <MetaTags title={pageTitle} />
         <title>{pageTitle}</title>
-        <script
-          defer
-          data-domain="hawaiiansintech.org"
-          src="https://plausible.io/js/script.js"
-        ></script>
       </Head>
       <Nav primaryNav={{ show: true }} />
       <div className="home-splash">

--- a/pages/join/01-you.tsx
+++ b/pages/join/01-you.tsx
@@ -3,6 +3,7 @@ import { Heading, Subheading } from "@/components/Heading";
 import BasicInformationForm from "@/components/intake-form/BasicInformation";
 import MetaTags from "@/components/Metatags";
 import Nav from "@/components/Nav";
+import Plausible from "@/components/Plausible";
 import { useStorage } from "@/lib/hooks";
 import { clearAllStoredFields } from "@/lib/utils";
 import Head from "next/head";
@@ -67,6 +68,7 @@ export default function JoinStep1({ pageTitle }) {
   return (
     <>
       <Head>
+        <Plausible />
         <MetaTags title={pageTitle} />
         <title>{pageTitle}</title>
       </Head>

--- a/pages/join/02-work.tsx
+++ b/pages/join/02-work.tsx
@@ -5,6 +5,7 @@ import WorkExperience, {
 } from "@/components/intake-form/WorkExperience";
 import MetaTags from "@/components/Metatags";
 import Nav from "@/components/Nav";
+import Plausible from "@/components/Plausible";
 import { getFilters } from "@/lib/api";
 import { FirebaseTablesEnum } from "@/lib/enums";
 import { useStorage } from "@/lib/hooks";
@@ -83,6 +84,7 @@ export default function JoinStep2({ focuses, pageTitle }) {
   return (
     <>
       <Head>
+        <Plausible />
         <MetaTags title={pageTitle} />
         <title>{pageTitle}</title>
       </Head>

--- a/pages/join/03-company.tsx
+++ b/pages/join/03-company.tsx
@@ -14,6 +14,7 @@ import { Heading } from "@/components/Heading";
 import { WorkExperienceWarning } from "@/components/intake-form/WorkExperience";
 import MetaTags from "@/components/Metatags";
 import Nav from "@/components/Nav";
+import Plausible from "@/components/Plausible";
 import { getFilters } from "@/lib/api";
 import { CompanySizeEnum, FirebaseTablesEnum } from "@/lib/enums";
 import { useStorage, useWindowWidth } from "@/lib/hooks";
@@ -153,6 +154,7 @@ export default function JoinStep3({ industries, pageTitle }) {
   return (
     <>
       <Head>
+        <Plausible />
         <MetaTags title={pageTitle} />
         <title>{pageTitle}</title>
       </Head>

--- a/pages/join/04-contact.tsx
+++ b/pages/join/04-contact.tsx
@@ -7,6 +7,7 @@ import ProgressBar from "@/components/form/ProgressBar";
 import { Heading, Subheading } from "@/components/Heading";
 import MetaTags from "@/components/Metatags";
 import Nav from "@/components/Nav";
+import Plausible from "@/components/Plausible";
 import { useStorage } from "@/lib/hooks";
 import { clearAllStoredFields, useInvalid } from "@/lib/utils";
 import { Formik } from "formik";
@@ -129,6 +130,7 @@ export default function JoinStep4({ pageTitle }) {
   return (
     <>
       <Head>
+        <Plausible />
         <MetaTags title={pageTitle} />
         <title>{pageTitle}</title>
       </Head>

--- a/pages/join/thank-you.tsx
+++ b/pages/join/thank-you.tsx
@@ -1,5 +1,6 @@
 import HitLogo from "@/components/HitLogo";
 import MetaTags from "@/components/Metatags";
+import Plausible from "@/components/Plausible";
 import { Subtitle } from "@/components/Title";
 import Head from "next/head";
 import Link from "next/link";
@@ -17,6 +18,7 @@ export default function ThankYou({ pageTitle }) {
   return (
     <>
       <Head>
+        <Plausible />
         <MetaTags title={pageTitle} />
         <title>{pageTitle}</title>
       </Head>


### PR DESCRIPTION
Realized after pushing it up that I only managed to add it to the homepage. This PR adds it to all existing pages.

My read is this eventually should be improved. I haven't found anything immediately to apply in the [Head docs](https://nextjs.org/docs/pages/api-reference/components/head)... but I'll be the first to admit this repetition "smells" pretty bad.