### PR TITLE
Adding initial Firestore Converter

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -6,17 +6,24 @@ import {
   getDocs,
 } from "firebase/firestore";
 import { FirebaseTablesEnum, StatusEnum, YearsOfExperienceEnum } from "./enums";
-import { Member, memberConverter } from "./firestore-converters/member";
+import { memberConverter } from "./firestore-converters/member";
 
 const statusEnumValues = Object.values(StatusEnum);
 
-export interface MemberPublic extends Member {
+export interface MemberPublic {
+  name?: string;
+  companySize?: string;
   emailAbbr?: string;
   focus?: { name: string; id: string }[] | string[];
   focusSuggested?: string;
+  id?: string;
   industry?: { name: string; id: string }[] | string[];
   industrySuggested?: string;
+  link?: string;
+  location?: string;
   region?: string;
+  title?: string;
+  yearsExperience?: string;
 }
 
 export interface MemberPublicEditing extends MemberPublic {

--- a/lib/firebase-admin.ts
+++ b/lib/firebase-admin.ts
@@ -1,0 +1,10 @@
+import * as admin from "firebase-admin";
+
+export const initializeAdmin = async () => {
+  if (!admin.apps.length) {
+    const serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_KEY);
+    admin.initializeApp({
+      credential: admin.credential.cert(serviceAccount),
+    });
+  }
+};

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,5 +1,4 @@
 import { getFirestore } from "@firebase/firestore";
-import admin from "firebase-admin";
 import { initializeApp } from "firebase/app";
 import { getAuth, GoogleAuthProvider, signInWithPopup } from "firebase/auth";
 import { getStorage } from "firebase/storage";
@@ -37,12 +36,4 @@ export const signOutWithGoogle = () => {
   auth.signOut();
   sessionStorage.removeItem("user");
   location.reload();
-};
-export const initializeAdmin = async () => {
-  if (!admin.apps.length) {
-    const serviceAccount = JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT_KEY);
-    admin.initializeApp({
-      credential: admin.credential.cert(serviceAccount),
-    });
-  }
 };

--- a/lib/firestore-converters/common.ts
+++ b/lib/firestore-converters/common.ts
@@ -1,0 +1,17 @@
+export function checkType<T>(
+  value: unknown,
+  field: string,
+  member_name: string,
+  expectedType: string
+): T | null {
+  if (value == undefined || value == null) {
+    return null;
+  }
+  if (typeof value !== expectedType) {
+    console.warn(
+      `Expected ${expectedType}, got ${typeof value} for value ${value}. Field: ${field}. Member: ${member_name}`
+    );
+    return null;
+  }
+  return value as T;
+}

--- a/lib/firestore-converters/member.ts
+++ b/lib/firestore-converters/member.ts
@@ -1,0 +1,108 @@
+import {
+  DocumentData,
+  DocumentReference,
+  FirestoreDataConverter,
+  QueryDocumentSnapshot,
+  serverTimestamp,
+  Timestamp,
+} from "@firebase/firestore";
+import {
+  CompanySizeEnum,
+  FirebaseDefaultValuesEnum,
+  StatusEnum,
+  YearsOfExperienceEnum,
+} from "../enums";
+import { checkType } from "./common";
+
+export class Member {
+  constructor(
+    public companySize: CompanySizeEnum,
+    public focuses: DocumentReference[],
+    public industries: DocumentReference[],
+    public link: string,
+    public location: string,
+    public maskedEmail: string,
+    public name: string,
+    public regions: DocumentReference[],
+    public title: string,
+    public yearsExperience: YearsOfExperienceEnum,
+    public id?: string,
+    public lastModified?: Timestamp,
+    public lastModifiedBy?: DocumentReference | string,
+    public requests?: string,
+    public status?: StatusEnum,
+    public unsubscribed?: boolean
+  ) {}
+
+  toString() {
+    return (
+      this.name +
+      " - status: {" +
+      this.status +
+      "} - created at " +
+      this.lastModified.toDate().toLocaleString()
+    );
+  }
+}
+
+export const memberConverter: FirestoreDataConverter<Member> = {
+  toFirestore(user: Member): DocumentData {
+    return {
+      company_size: user.companySize,
+      focuses: user.focuses,
+      industries: user.industries,
+      link: user.link,
+      location: user.location,
+      masked_email: user.maskedEmail,
+      name: user.name,
+      regions: user.regions,
+      title: user.title,
+      years_experience: user.yearsExperience,
+      last_modified: user.lastModified || serverTimestamp(),
+      last_modified_by:
+        user.lastModifiedBy || FirebaseDefaultValuesEnum.LAST_MODIFIED_BY,
+      requests: user.requests || "",
+      status: user.status || StatusEnum.PENDING,
+      unsubscribed: user.unsubscribed || false,
+    };
+  },
+
+  fromFirestore(snapshot: QueryDocumentSnapshot): Member {
+    const data = snapshot.data();
+    const name = data.name;
+    return new Member(
+      checkType<CompanySizeEnum>(
+        data.company_size,
+        "company_size",
+        name,
+        "string"
+      ),
+      checkType<DocumentReference[]>(data.focuses, "focuses", name, "object"),
+      checkType<DocumentReference[]>(
+        data.industries,
+        "industries",
+        name,
+        "object"
+      ),
+      checkType<string>(data.link, "link", name, "string"),
+      checkType<string>(data.location, "location", name, "string"),
+      checkType<string>(data.masked_email, "masked_email", name, "string"),
+      checkType<string>(data.name, "name", name, "string"),
+      checkType<DocumentReference[]>(data.regions, "regions", name, "object"),
+      checkType<string>(data.title, "title", name, "string"),
+      checkType<YearsOfExperienceEnum>(
+        data.years_experience,
+        "years_experience",
+        name,
+        "string"
+      ),
+      snapshot.id,
+      checkType<Timestamp>(data.last_modified, "last_modified", name, "object"),
+      data.last_modified_by || null,
+      checkType<string>(data.requests, "requests", name, "string"),
+      checkType<StatusEnum>(data.status, "status", name, "string") ||
+        StatusEnum.PENDING,
+      checkType<boolean>(data.unsubscribed, "unsubscribed", name, "boolean")
+    );
+  },
+};

--- a/lib/stubApi.ts
+++ b/lib/stubApi.ts
@@ -1,6 +1,6 @@
 import { Filter, MemberPublic } from "./api";
+import { CompanySizeEnum, YearsOfExperienceEnum } from "./enums";
 export type { MemberPublic };
-
 /**
  * Stubbed function to simulate fetching technologists
  * without connecting to firebase.
@@ -11,7 +11,7 @@ export type { MemberPublic };
 interface MemberPublicDupe {
   name?: string;
   companySize?: string;
-  emailAbbr?: string[];
+  emailAbbr?: string;
   focus?: { name: string; id: string }[] | string[];
   focusSuggested?: string;
   id?: string;
@@ -24,7 +24,7 @@ interface MemberPublicDupe {
   yearsExperience?: string;
 }
 
-export function getMembers(): MemberPublic[] {
+export function getMembers(): MemberPublicDupe[] {
   return [
     {
       id: "fakeMemberID01",
@@ -36,8 +36,8 @@ export function getMembers(): MemberPublic[] {
       link: "https://linkedin.com/in/andrewtaeoalii",
       focus: [{ name: "Engineering", id: "fakeFocusID01" }],
       industry: [{ name: "Internet / Technology", id: "fakeIndustryID01" }],
-      companySize: "5000 – 1000",
-      yearsExperience: "10 – 19 years",
+      companySize: CompanySizeEnum.FIVE_THOUSAND_TO_TEN_THOUSAND,
+      yearsExperience: YearsOfExperienceEnum.TEN_TO_NINETEEN,
     },
     {
       id: "fakeMemberID02",
@@ -49,8 +49,9 @@ export function getMembers(): MemberPublic[] {
       emailAbbr: "k...i@hawaiiansintech.org",
       focus: [{ name: "Engineering", id: "fakeFocusID01" }],
       industry: [{ name: "Healthcare", id: "fakeIndustryID02" }],
-      companySize: "1000 – 4999",
-      yearsExperience: "3 – 4 years",
+      companySize:
+        CompanySizeEnum.ONE_THOUSAND_TO_FOUR_THOUSAND_NINE_HUNDRED_NINETY_NINE,
+      yearsExperience: YearsOfExperienceEnum.TEN_TO_NINETEEN,
     },
     {
       id: "fakeMemberID03",
@@ -65,8 +66,9 @@ export function getMembers(): MemberPublic[] {
         { name: "Design", id: "fakeFocusID02" },
       ],
       industry: [{ name: "Internet / Technology", id: "fakeIndustryID01" }],
-      companySize: "1000 – 4999",
-      yearsExperience: "10 – 19 years",
+      companySize:
+        CompanySizeEnum.ONE_THOUSAND_TO_FOUR_THOUSAND_NINE_HUNDRED_NINETY_NINE,
+      yearsExperience: YearsOfExperienceEnum.TEN_TO_NINETEEN,
     },
   ];
 }

--- a/pages/api/create-member.tsx
+++ b/pages/api/create-member.tsx
@@ -7,7 +7,8 @@ import {
   FirebaseTablesEnum,
   StatusEnum,
 } from "@/lib/enums";
-import { db, initializeAdmin } from "@/lib/firebase";
+import { db } from "@/lib/firebase";
+import { initializeAdmin } from "@/lib/firebase-admin";
 import Client from "@sendgrid/client";
 import SendGrid from "@sendgrid/mail";
 import * as admin from "firebase-admin";

--- a/pages/api/create-request.tsx
+++ b/pages/api/create-request.tsx
@@ -4,7 +4,7 @@ import {
   sendRequestUpdateEmail,
 } from "@/lib/email/request-update-email";
 import { FirebaseTablesEnum } from "@/lib/enums";
-import { initializeAdmin } from "@/lib/firebase";
+import { initializeAdmin } from "@/lib/firebase-admin";
 import * as admin from "firebase-admin";
 
 const addRequest = async (


### PR DESCRIPTION
### Overview

Adding initial firestore converter, minor cleanup on intialize admin

### Purpose

As @ataeoalii mentioned in [this comment in a previous PR](https://github.com/hawaiians/hawaiiansintech/pull/8#discussion_r1186639031), we should likely start using [firestore converters](https://firebase.google.com/docs/reference/js/firestore_.firestoredataconverter) going forward. This PR is to make that initial step by creating the first one for Member data

### Implementation changes

1. Adding firestore converter Member class and type checking function
2. Updating the `api.ts` file to use the Member class
3. Putting `initializeAdmin()` into it's own file and updating accordingly

Note: Currently the toFirestore() function in the Member class is not being used but requires that function to be present so a draft of it was made
