### PR TITLE
Adds outbound link clicks via Plausible script extension

### DIFF
--- a/components/Plausible.tsx
+++ b/components/Plausible.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 
 export default function Plausible() {
+  // see https://plausible.io/docs/outbound-link-click-tracking
+
   return (
     <script
       defer
       data-domain="hawaiiansintech.org"
-      src="https://plausible.io/js/script.js"
-    />
+      src="https://plausible.io/js/script.outbound-links.js"
+    ></script>
   );
 }


### PR DESCRIPTION
**[Instructions in docs](https://plausible.io/docs/outbound-link-click-tracking)**

- Followed docs to swap the script
  > Change your Plausible script snippet src attribute from https://plausible.io/js/script.js to https://plausible.io/js/script.outbound-links.js
  > 
  > The new snippet will look like this (make sure to change the data-domain attribute to the domain you added to Plausible):
  > 
  > <script defer data-domain="yourdomain.com" src="https://plausible.io/js/script.outbound-links.js"></script>
  > 
  > Do this for all the websites where you'd like to enable outbound link click tracking. This is the only tracking script you need. You don't need to keep the old script. Your stats will keep tracking without interruption, and you won't lose any of your old data.
- Added event to plausible dashboard.
![image](https://github.com/hawaiians/hawaiiansintech/assets/5141111/567038cb-bd0c-4669-8676-9dc650c18dd1)