### PR TITLE
Add May newsletter email

### DIFF
--- a/emails/_newsletter-042024.tsx
+++ b/emails/_newsletter-042024.tsx
@@ -1,0 +1,147 @@
+import { Text, Link, Section } from "@react-email/components";
+import * as React from "react";
+import Base from "./ui/base";
+import Logo from "./ui/logo";
+import Layout from "./ui/layout";
+import List from "./ui/list";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export default function _Newsletter() {
+  return (
+    <Base
+      preview="Our little hui grows by one (yeah, you)"
+      title="Welcome to Hawaiians in Tech"
+      align="left"
+    >
+      <Section className="pt-8">
+        <Logo />
+        <Text className="text-center text-2xl font-semibold">
+          <em>Huuui!</em> A Bay Area announcement!
+        </Text>
+      </Section>
+      <Layout border={false}>
+        <Text>Aloha e gangie,</Text>
+        <Text>
+          I&rsquo;m stoked to extand an invite to all members of our Hawaiians
+          in Tech hui to our very first community event we&rsquo;re co-hosting
+          right here in the Bay Area! Mahalo to our friends at both the Amazon
+          and Google Pasifika chapters for their kokua in getting us all
+          together and for their generous support of this event.
+        </Text>
+      </Layout>
+      <Layout accentColor="violet">
+        <Text className="my-0 inline-block rounded-full bg-violet-100 px-2 py-1 text-xs font-semibold tracking-wide text-violet-800">
+          BAY AREA COMMUNITY EVENT
+        </Text>
+        <Text className="mb-2 text-base">
+          Wednesday, May 29th, 2024, 5:30 – 8PM
+        </Text>
+        <Text className="mb-2 mt-0 text-2xl font-semibold">
+          Pasifika in Tech Happy Hour @ Twitch HQ
+        </Text>
+        <Link
+          href="https://maps.app.goo.gl/grtUs962CMPEkXaP9"
+          className="mb-12 text-inherit"
+        >
+          <Text className="inline font-bold text-violet-700">Twitch</Text>
+          <Text className="inline font-normal text-inherit">
+            350 Bush St., SF, CA 94104
+          </Text>
+        </Link>
+      </Layout>
+      <Layout border={false}>
+        <Text className="m-0 mb-4 text-base font-semibold tracking-wide">
+          RSVP to this email
+        </Text>
+        <List
+          nodes={[
+            {
+              icon: "✅",
+              label: (
+                <>
+                  <strong>... you&rsquo;re planning to make it!</strong> A loose
+                  headcount will help us make sure there&rsquo;s enough food and
+                  drinks for everyone. We also plan to send out a calendar
+                  invite as the event approaches.
+                </>
+              ),
+            },
+            {
+              icon: "🌺",
+              label: (
+                <>
+                  <strong>
+                    ... want to send your aloha but cannot make it.
+                  </strong>{" "}
+                  It&rsquo;d be great to figure out your situation so we can
+                  make sure you&rsquo;d be able to join us next time (like, a
+                  weekend potluck at Golden Gate Park, anyone?)
+                </>
+              ),
+            },
+            {
+              icon: "💼",
+              label: (
+                <>
+                  <strong>
+                    ... have a Pasifika-focused group or hui at your work.
+                  </strong>{" "}
+                  Drop us a line—we&rsquo;d love to expand our network and build
+                  pilina with more of our Pacific Islander ʻohana across the
+                  tech industry!
+                </>
+              ),
+            },
+            // {
+            //   icon: "🌺",
+            //   label: (
+            //     <>
+            //       <strong>Want to help support our lei-making workshop.</strong>{" "}
+            //       The day will really be about hanging out and talking story,
+            //       but we&rsquo;d love to have an activity to give everyone
+            //       something fun to do.
+            //     </>
+            //   ),
+            // },
+            {
+              icon: "💡",
+              label: (
+                <>
+                  <strong>
+                    ... have any questions or ideas for the event.
+                  </strong>{" "}
+                  The day will really be about hanging out and talking story,
+                  but if you have any questions, thoughts, or concerns, please
+                  feel free to let us know.
+                </>
+              ),
+            },
+          ]}
+        />
+        <Text>
+          It&rsquo;d be great to see many of you for the first time at this
+          casual pau hana event. We are hoping to make this a regular thing, so
+          come out and help us kick it off right!
+        </Text>
+        <Text className="mb-0">E ola,</Text>
+        <Text className="mt-0">Taylor Kekai Ho</Text>
+      </Layout>
+      <Text className="my-0 text-center text-stone-500">
+        <Link
+          href="https://hawaiiansintech.org/about?utm_source=confirmation-email-footer"
+          className="text-xs text-inherit"
+        >
+          About
+        </Link>
+        <span className="mx-1">·</span>
+        <Link
+          href="https://hawaiiansintech.org/privacy-policy?utm_source=confirmation-email-footer"
+          className="text-xs text-inherit"
+        >
+          Privacy Policy
+        </Link>
+      </Text>
+    </Base>
+  );
+}

--- a/emails/_newsletter-042024.tsx
+++ b/emails/_newsletter-042024.tsx
@@ -1,9 +1,8 @@
-import { Text, Link, Section, Hr } from "@react-email/components";
+import { Text, Link, Hr, Img } from "@react-email/components";
 import * as React from "react";
 import Base from "./ui/base";
 import Logo from "./ui/logo";
 import Layout from "./ui/layout";
-import List from "./ui/list";
 
 export default function _Newsletter() {
   return (
@@ -12,122 +11,119 @@ export default function _Newsletter() {
       title="Welcome to Hawaiians in Tech"
       align="left"
     >
-      <Layout border={false}>
+      <Layout>
         <Logo align="left" />
         <Text>
-          <span className="block text-lg font-semibold leading-loose">
+          <span className="block text-base font-semibold leading-loose sm:text-lg">
             <em>Huuui!</em> Hawaiians in Tech
           </span>
-          <strong className="text-5xl font-semibold">April Newsletter</strong>
+          <strong className="text-2xl font-semibold sm:text-5xl">
+            May Newsletter
+          </strong>
         </Text>
         <Text>Aloha e gangie,</Text>
         <Text>
-          We&rsquo;re excited to extand an invite to all members of our
-          Hawaiians in Tech hui to our very first community event we&rsquo;re
-          co-hosting in the Bay Area! Mahalo to our friends at both the Amazon
-          and Google Pasifika chapters for their kokua in getting us all
-          together and for their generous support of this event.
+          Hope everyone has been doing swell. What a ride it&rsquo;s been over
+          the last few months, right? <em>ʻĀuwe.</em> Whether in a new job,
+          newly without a job, or in a newly stressful job, many of us are going
+          through it. Stand strong; we are here for each other. To make space
+          for that, we&rsquo;re excited to announce we&rsquo;re co-hosting our
+          first in-person event in the Bay Area!
         </Text>
-      </Layout>
-      <Layout accentColor="violet">
-        <Text className="my-0 inline-block rounded-full bg-violet-100 px-2 py-1 text-xs font-semibold tracking-wide text-violet-800">
-          BAY AREA COMMUNITY EVENT
+        <Link href="https://lu.ma/ofzvwvaj">
+          <Img
+            src="https://tj8xrxsxqdtxeknk.public.blob.vercel-storage.com/email/pasifika%20postcard-Qqsb3Z578u3UXtzGx05GxFL12L6ZSH.jpg"
+            alt="Flyer"
+            className="h-auto w-full rounded"
+          />
+        </Link>
+        <Text>
+          You&rsquo;re invited to the inaugural{" "}
+          <strong>Pasifika in Tech Bay Area Happy Hour</strong>! Join us to
+          celebrate and connect with our vibrant Polynesian, Melanesian, &
+          Micronesian tech community in the Bay Area.
         </Text>
-        <Text className="mb-2 text-base">
-          Wednesday, May 29th, 2024, 5:30 – 8PM
+        <Text className="my-1">
+          <strong>Save the date:</strong> Wednesday, May 29th
         </Text>
-        <Text className="mb-2 mt-0 text-2xl font-semibold">
-          Pasifika in Tech Happy Hour @ Twitch HQ
+        <Text className="my-1">
+          <strong>Time:</strong> 5:30–8PM
+        </Text>
+        <Text className="my-1">
+          <strong>Location:</strong> Twitch HQ (
+          <Link
+            className="text-brown-600"
+            href="https://maps.app.goo.gl/anb6ZbxZpMwXffwn6"
+          >
+            map
+          </Link>
+          )
+        </Text>
+        <Text className="my-1">
+          <strong>What to expect:</strong>
+        </Text>
+        <ul className="mt-0 text-sm">
+          <li className="mb-1">Network with Pasifika techies and allies</li>
+          <li className="my-1">Enjoy Pasifika music, food & drinks</li>
+          <li className="mt-1">
+            Fun activities being planned including a lei-making workshop and,
+            yes since this is Twitch, free arcade access with games like Killer
+            Queen and pinball
+          </li>
+        </ul>
+        <Text className="mb-2 text-center">
+          Space is limited. Let us know you&rsquo;re coming!
         </Text>
         <Link
-          href="https://maps.app.goo.gl/grtUs962CMPEkXaP9"
-          className="text-inherit"
+          href="https://lu.ma/ofzvwvaj"
+          className="block rounded bg-stone-800 px-2.5 py-2 text-center font-bold tracking-wide text-white"
         >
-          <Text className="inline font-bold text-violet-700">Twitch</Text>
-          <Text className="inline font-normal text-inherit">
-            350 Bush St., SF, CA 94104
+          RSVP{" "}
+          <Text className="mb-0 mt-1 text-center text-xs font-semibold text-stone-300">
+            May 29th 5:30–8PM @ Twitch HQ
           </Text>
         </Link>
-        <Section>
-          <Text className="mb-4 mt-8 text-base font-bold tracking-wide">
-            RSVP to this email if you...
+        <div className="mb-8 mt-4 sm:px-4">
+          <Img
+            className="w-full"
+            src="https://tj8xrxsxqdtxeknk.public.blob.vercel-storage.com/email/pasifika%20orgs-9izCj4uKUVq7xr1It0nwZF0L17abk0.png"
+          />
+        </div>
+        <div className="rounded bg-stone-100 p-2 text-center sm:p-4">
+          <Text className="mb-2 mt-0 text-xs font-bold">
+            Then,{" "}
+            <Link href="https://lu.ma/ofzvwvaj" className="text-brown-600">
+              share the RSVP
+            </Link>{" "}
+            with your Pasifika friends and colleagues
           </Text>
-        </Section>
-        <List
-          nodes={[
-            {
-              icon: "✅",
-              label: (
-                <>
-                  <strong>... can make it!</strong> A loose headcount will help
-                  us make sure there&rsquo;s enough food and drinks for
-                  everyone. We also plan to send out a calendar invite with more
-                  details as the event approaches.
-                </>
-              ),
-            },
-            {
-              icon: "🌺",
-              label: (
-                <>
-                  <strong>
-                    ... want to send your aloha but will miss this one.
-                  </strong>{" "}
-                  It&rsquo;d be great to figure out your situation so we can
-                  make sure you&rsquo;d be able to join us next time (like, a
-                  weekend potluck at Golden Gate Park, anyone?)
-                </>
-              ),
-            },
-            {
-              icon: "💼",
-              label: (
-                <>
-                  <strong>
-                    ... have a Pasifika-focused group or hui at your work.
-                  </strong>{" "}
-                  Drop us a line—we&rsquo;d love to expand our network and build
-                  pilina with more of our Pacific Islander ʻohana across the
-                  tech industry!
-                </>
-              ),
-            },
-            // {
-            //   icon: "🌺",
-            //   label: (
-            //     <>
-            //       <strong>Want to help support our lei-making workshop.</strong>{" "}
-            //       The day will really be about hanging out and talking story,
-            //       but we&rsquo;d love to have an activity to give everyone
-            //       something fun to do.
-            //     </>
-            //   ),
-            // },
-            {
-              icon: "💡",
-              label: (
-                <>
-                  <strong>
-                    ... have any questions or ideas for this or future events.
-                  </strong>{" "}
-                  The day will really be about hanging out and talking story! If
-                  you have any mānaʻo to share, please feel free to let us know.
-                </>
-              ),
-            },
-          ]}
-        />
-      </Layout>
-      <Layout border={false}>
-        <Text className="mt-0">
-          Can&rsquo;t wait to catch up with everyone, old friends and new, at
-          this casual pau hana. We are hoping to make this a regular thing, so
-          come out and help us kick it off right!
+          <Link href="https://tj8xrxsxqdtxeknk.public.blob.vercel-storage.com/email/pasifika%20flyer-N4j5yIwk22Hb15ESQdYKzHq6LH6K9t.jpg">
+            <Img
+              className="mr-4 inline-block w-1/3 rounded"
+              src="https://tj8xrxsxqdtxeknk.public.blob.vercel-storage.com/email/pasifika%20flyer-N4j5yIwk22Hb15ESQdYKzHq6LH6K9t.jpg"
+            />
+          </Link>
+          <Link href="https://tj8xrxsxqdtxeknk.public.blob.vercel-storage.com/email/pasifika%20postcard-Qqsb3Z578u3UXtzGx05GxFL12L6ZSH.jpg">
+            <Img
+              className="inline-block w-1/3 rounded"
+              src="https://tj8xrxsxqdtxeknk.public.blob.vercel-storage.com/email/pasifika%20postcard-Qqsb3Z578u3UXtzGx05GxFL12L6ZSH.jpg"
+            />
+          </Link>
+          <Text className="mb-0 mt-2 text-xs leading-normal text-stone-500">
+            Feel free to spruce up social posts with either of the full-res
+            graphics made specifically for the event.
+          </Text>
+        </div>
+        <Text>
+          Mahalo to everyone for their kokua and generous support in making this
+          event happen! Stoked to have collaborated with plenty folks including,
+          but not limited to, friends from Amazon&rsquo;s Pasifika Indigenous@,
+          Hawaiians in Tech, Google Pasifika Peoples Collective, and Apple. E
+          paʻi ka lima kākou!
         </Text>
-      </Layout>
-      <Layout border={false}>
         <Text className="m-0">E mālama,</Text>
         <Text className="m-0">Taylor Kekai Ho</Text>
+        <Text className="m-0">Hawaiians in Tech</Text>
       </Layout>
       <Text className="my-0 text-center text-stone-500">
         <Link

--- a/emails/_newsletter-042024.tsx
+++ b/emails/_newsletter-042024.tsx
@@ -4,8 +4,6 @@ import Base from "./ui/base";
 import Logo from "./ui/logo";
 import Layout from "./ui/layout";
 import List from "./ui/list";
-import { buttonVariants } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 
 export default function _Newsletter() {
   return (
@@ -52,19 +50,21 @@ export default function _Newsletter() {
         </Link>
       </Layout>
       <Layout border={false}>
-        <Text className="m-0 mb-4 text-center text-base font-semibold tracking-wide">
-          RSVP to this email
-        </Text>
+        <Section className="text-center">
+          <Text className="m-0 mb-4 inline-block rounded-full bg-stone-800 px-4 py-1 text-center text-sm font-semibold tracking-wider text-white">
+            RSVP to this email
+          </Text>
+        </Section>
         <List
           nodes={[
             {
               icon: "✅",
               label: (
                 <>
-                  <strong>... you&rsquo;re planning to make it!</strong> A loose
-                  headcount will help us make sure there&rsquo;s enough food and
-                  drinks for everyone. We also plan to send out a calendar
-                  invite as the event approaches.
+                  <strong>... if you can make it!</strong> A loose headcount
+                  will help us make sure there&rsquo;s enough food and drinks
+                  for everyone. We also plan to send out a calendar invite with
+                  more details as the event approaches.
                 </>
               ),
             },
@@ -73,7 +73,7 @@ export default function _Newsletter() {
               label: (
                 <>
                   <strong>
-                    ... want to send your aloha but cannot make it.
+                    ... want to send your aloha but will miss this one.
                   </strong>{" "}
                   It&rsquo;d be great to figure out your situation so we can
                   make sure you&rsquo;d be able to join us next time (like, a
@@ -121,11 +121,11 @@ export default function _Newsletter() {
           ]}
         />
         <Text>
-          It&rsquo;d be great to see many of you for the first time at this
-          casual pau hana event. We are hoping to make this a regular thing, so
+          Can&rsquo;t wait to catch up with everyone, old friends and new, at
+          this casual pau hana. We are hoping to make this a regular thing, so
           come out and help us kick it off right!
         </Text>
-        <Text className="mb-0">E ola,</Text>
+        <Text className="mb-0">E mālama,</Text>
         <Text className="mt-0">Taylor Kekai Ho</Text>
       </Layout>
       <Text className="my-0 text-center text-stone-500">

--- a/emails/_newsletter-042024.tsx
+++ b/emails/_newsletter-042024.tsx
@@ -1,4 +1,4 @@
-import { Text, Link, Section } from "@react-email/components";
+import { Text, Link, Section, Hr } from "@react-email/components";
 import * as React from "react";
 import Base from "./ui/base";
 import Logo from "./ui/logo";
@@ -8,7 +8,7 @@ import List from "./ui/list";
 export default function _Newsletter() {
   return (
     <Base
-      preview="Our little hui grows by one (yeah, you)"
+      preview="Our first community event in the Bay Area!"
       title="Welcome to Hawaiians in Tech"
       align="left"
     >
@@ -18,7 +18,7 @@ export default function _Newsletter() {
           <span className="block text-lg font-semibold leading-loose">
             <em>Huuui!</em> Hawaiians in Tech
           </span>
-          <strong className="text-5xl font-semibold">Newsletter</strong>
+          <strong className="text-5xl font-semibold">April Newsletter</strong>
         </Text>
         <Text>Aloha e gangie,</Text>
         <Text>
@@ -41,18 +41,16 @@ export default function _Newsletter() {
         </Text>
         <Link
           href="https://maps.app.goo.gl/grtUs962CMPEkXaP9"
-          className="mb-12 text-inherit"
+          className="text-inherit"
         >
           <Text className="inline font-bold text-violet-700">Twitch</Text>
           <Text className="inline font-normal text-inherit">
             350 Bush St., SF, CA 94104
           </Text>
         </Link>
-      </Layout>
-      <Layout border={false}>
-        <Section className="text-center">
-          <Text className="m-0 mb-4 inline-block rounded-full bg-stone-800 px-4 py-1 text-center text-sm font-semibold tracking-wider text-white">
-            RSVP to this email
+        <Section>
+          <Text className="mb-4 mt-8 text-base font-bold tracking-wide">
+            RSVP to this email if you...
           </Text>
         </Section>
         <List
@@ -61,10 +59,10 @@ export default function _Newsletter() {
               icon: "✅",
               label: (
                 <>
-                  <strong>... if you can make it!</strong> A loose headcount
-                  will help us make sure there&rsquo;s enough food and drinks
-                  for everyone. We also plan to send out a calendar invite with
-                  more details as the event approaches.
+                  <strong>... can make it!</strong> A loose headcount will help
+                  us make sure there&rsquo;s enough food and drinks for
+                  everyone. We also plan to send out a calendar invite with more
+                  details as the event approaches.
                 </>
               ),
             },
@@ -110,23 +108,26 @@ export default function _Newsletter() {
               label: (
                 <>
                   <strong>
-                    ... have any questions or ideas for the event.
+                    ... have any questions or ideas for this or future events.
                   </strong>{" "}
-                  The day will really be about hanging out and talking story,
-                  but if you have any questions, thoughts, or concerns, please
-                  feel free to let us know.
+                  The day will really be about hanging out and talking story! If
+                  you have any mānaʻo to share, please feel free to let us know.
                 </>
               ),
             },
           ]}
         />
-        <Text>
+      </Layout>
+      <Layout border={false}>
+        <Text className="mt-0">
           Can&rsquo;t wait to catch up with everyone, old friends and new, at
           this casual pau hana. We are hoping to make this a regular thing, so
           come out and help us kick it off right!
         </Text>
-        <Text className="mb-0">E mālama,</Text>
-        <Text className="mt-0">Taylor Kekai Ho</Text>
+      </Layout>
+      <Layout border={false}>
+        <Text className="m-0">E mālama,</Text>
+        <Text className="m-0">Taylor Kekai Ho</Text>
       </Layout>
       <Text className="my-0 text-center text-stone-500">
         <Link

--- a/emails/_newsletter-042024.tsx
+++ b/emails/_newsletter-042024.tsx
@@ -14,18 +14,19 @@ export default function _Newsletter() {
       title="Welcome to Hawaiians in Tech"
       align="left"
     >
-      <Section className="pt-8">
-        <Logo />
-        <Text className="text-center text-2xl font-semibold">
-          <em>Huuui!</em> A Bay Area announcement!
-        </Text>
-      </Section>
       <Layout border={false}>
+        <Logo align="left" />
+        <Text>
+          <span className="block text-lg font-semibold leading-loose">
+            <em>Huuui!</em> Hawaiians in Tech
+          </span>
+          <strong className="text-5xl font-semibold">Newsletter</strong>
+        </Text>
         <Text>Aloha e gangie,</Text>
         <Text>
-          I&rsquo;m stoked to extand an invite to all members of our Hawaiians
-          in Tech hui to our very first community event we&rsquo;re co-hosting
-          right here in the Bay Area! Mahalo to our friends at both the Amazon
+          We&rsquo;re excited to extand an invite to all members of our
+          Hawaiians in Tech hui to our very first community event we&rsquo;re
+          co-hosting in the Bay Area! Mahalo to our friends at both the Amazon
           and Google Pasifika chapters for their kokua in getting us all
           together and for their generous support of this event.
         </Text>
@@ -51,7 +52,7 @@ export default function _Newsletter() {
         </Link>
       </Layout>
       <Layout border={false}>
-        <Text className="m-0 mb-4 text-base font-semibold tracking-wide">
+        <Text className="m-0 mb-4 text-center text-base font-semibold tracking-wide">
           RSVP to this email
         </Text>
         <List

--- a/emails/_newsletter-0524.tsx
+++ b/emails/_newsletter-0524.tsx
@@ -4,7 +4,7 @@ import Base from "./ui/base";
 import Logo from "./ui/logo";
 import Layout from "./ui/layout";
 
-export default function _Newsletter() {
+export default function _Newsletter0524() {
   return (
     <Base
       preview="Our first community event in the Bay Area!"

--- a/emails/_newsletter-0524.tsx
+++ b/emails/_newsletter-0524.tsx
@@ -7,7 +7,7 @@ import Layout from "./ui/layout";
 export default function _Newsletter0524() {
   return (
     <Base
-      preview="Our first community event in the Bay Area!"
+      preview="Join our first community event in the Bay Area!"
       title="Welcome to Hawaiians in Tech"
       align="left"
     >

--- a/emails/_newsletter-0524.tsx
+++ b/emails/_newsletter-0524.tsx
@@ -1,10 +1,14 @@
-import { Text, Link, Hr, Img } from "@react-email/components";
+import { Text, Link, Img, Container } from "@react-email/components";
 import * as React from "react";
 import Base from "./ui/base";
 import Logo from "./ui/logo";
 import Layout from "./ui/layout";
 
-export default function _Newsletter0524() {
+export default function _Newsletter0524({
+  unsubscribeUrl,
+}: {
+  unsubscribeUrl: string;
+}) {
   return (
     <Base
       preview="Join our first community event in the Bay Area!"
@@ -125,21 +129,25 @@ export default function _Newsletter0524() {
         <Text className="m-0">Taylor Kekai Ho</Text>
         <Text className="m-0">Hawaiians in Tech</Text>
       </Layout>
-      <Text className="my-0 text-center text-stone-500">
+      <Container className="my-4 text-center text-stone-500">
+        <Link href={`${unsubscribeUrl}`} className="text-xs text-inherit">
+          Unsubscribe
+        </Link>
+        <span className="mx-2">·</span>
         <Link
           href="https://hawaiiansintech.org/about?utm_source=confirmation-email-footer"
           className="text-xs text-inherit"
         >
           About
         </Link>
-        <span className="mx-1">·</span>
+        <span className="mx-2">·</span>
         <Link
           href="https://hawaiiansintech.org/privacy-policy?utm_source=confirmation-email-footer"
           className="text-xs text-inherit"
         >
           Privacy Policy
         </Link>
-      </Text>
+      </Container>
     </Base>
   );
 }

--- a/emails/login-prompt.tsx
+++ b/emails/login-prompt.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import Base from "./ui/base";
 import { Button, Link, Text } from "@react-email/components";
 import { DISCORD_URL } from "@/pages/about";
+import Layout from "./ui/layout";
+import Logo from "./ui/logo";
 
 export default function LoginPromptEmail({
   emailAddress = "[placeholder@hawaiiansintech.org]",
@@ -16,39 +18,42 @@ export default function LoginPromptEmail({
       title={`New Member Submission from ${promptLink}`}
       align="center"
     >
-      <Text className="text-3xl text-center">
-        Login Link for
-        <br />
-        <strong>Hawaiians in Tech</strong>
-      </Text>
-      <Text>
-        We just received a request to sign in to{" "}
-        <Link
-          href="https://hawaiiansintech.org/?utm_source=login-link-email-body"
-          className="font-semibold text-inherit underline"
+      <Layout>
+        <Logo />
+        <Text className="text-center text-3xl">
+          Login Link for
+          <br />
+          <strong>Hawaiians in Tech</strong>
+        </Text>
+        <Text>
+          We just received a request to sign in to{" "}
+          <Link
+            href="https://hawaiiansintech.org/?utm_source=login-link-email-body"
+            className="font-semibold text-inherit underline"
+          >
+            Hawaiians in Technology
+          </Link>{" "}
+          using this email address (
+          <span className="text-stone-500">{emailAddress}</span>). To log in to
+          your account, click the link below:
+        </Text>
+        <Button
+          href={promptLink}
+          className="rounded bg-brown-600 px-4 py-2 text-sm text-white"
         >
-          Hawaiians in Technology
-        </Link>{" "}
-        using this email address (
-        <span className="text-stone-500">{emailAddress}</span>). To log in to
-        your account, click the link below:
-      </Text>
-      <Button
-        href={promptLink}
-        className="bg-brown-600 text-white py-2 px-4 text-sm rounded"
-      >
-        Log In to Hawaiians in Tech
-      </Button>
-      <Text>
-        If you did not request this link, you can safely ignore this email.
-      </Text>
-      <Text className="text-stone-500 text-xs">
-        If the problem persists, please contact us on{" "}
-        <Link href={DISCORD_URL} className="text-inherit underline">
-          our Discord server
-        </Link>
-        .
-      </Text>
+          Log In to Hawaiians in Tech
+        </Button>
+        <Text>
+          If you did not request this link, you can safely ignore this email.
+        </Text>
+        <Text className="text-xs text-stone-500">
+          If the problem persists, please contact us on{" "}
+          <Link href={DISCORD_URL} className="text-inherit underline">
+            our Discord server
+          </Link>
+          .
+        </Text>
+      </Layout>
     </Base>
   );
 }

--- a/emails/pending-member-email.tsx
+++ b/emails/pending-member-email.tsx
@@ -5,6 +5,8 @@ import CTABlock from "./ui/cta-block";
 import Base from "./ui/base";
 import List from "./ui/list";
 import { MemberFields } from "@/pages/api/create-member";
+import Layout from "./ui/layout";
+import Logo from "./ui/logo";
 
 export default function PendingMemberEmail({
   name = "[Name Inoa]",
@@ -24,124 +26,130 @@ export default function PendingMemberEmail({
       preview={`New Member Submission from ${name}`}
       title={`New Member Submission from ${name}`}
     >
-      <Text className="px-4 text-center text-3xl">
-        Pending Submission
-        <br />
-        <strong>{name}</strong>
-      </Text>
-      <Text>
-        A new member <strong className="font-semibold">{name}</strong> (
-        <Link href={`mailto:${email}`} className="text-stone-500 underline">
-          {email}
-        </Link>
-        ) submitted their information.
-      </Text>
-      <List
-        nodes={[
-          {
-            icon: "💬",
-            label: (
-              <>
-                Check freeform fields
-                {title && (
-                  <>
-                    , including their title &ldquo;
-                    <strong className="font-semibold">{title}</strong>
-                    &rdquo;,
-                  </>
-                )}{" "}
-                for misspelling and/or appropriateness.
-                {suggestions.length > 0 && (
-                  <>
-                    {" "}
-                    They also suggested{" "}
-                    {suggestions.map((s, i) => (
-                      <span key={`suggestion-${i}`}>
-                        &ldquo;<strong className="font-semibold">{s}</strong>
-                        &rdquo;
-                        {(i < suggestions.length - 2 && ", ") ||
-                          (i === suggestions.length - 2 && " and ")}
-                      </span>
-                    ))}
-                    .
-                  </>
-                )}
-              </>
-            ),
-          },
-          {
-            icon: "🔗",
-            label: (
-              <>
-                Check that their URL works.{" "}
-                <Link
-                  href={link}
-                  className="font-semibold text-inherit underline"
-                >
-                  {link}
-                </Link>
-              </>
-            ),
-          },
-          {
-            icon: "🌏",
-            label: (
-              <>
-                Parse &ldquo;
-                <strong className="font-semibold">{location}</strong>&rdquo; for
-                the Location and indexed/searchable Region. Always try to merge,
-                when appropriate. Seek the use of proper diacriticals, where{" "}
-                <Link
-                  href="https://wehewehe.org"
-                  className="text-stone-500 underline"
-                >
-                  wehewehe.org
-                </Link>{" "}
-                is your friend!
-              </>
-            ),
-          },
-        ]}
-      />
-      <Text>
-        Move their Status to
-        <span className="mx-1 my-0 inline-block rounded-full bg-emerald-200 px-2 py-0.5 text-xs font-medium tracking-wide text-emerald-700">
-          APPROVED
-        </span>
-        when all looks well. Then, send a welcome email to let them know
-        they&rsquo;re in!
-      </Text>
-      <Text>
-        Move their status to
-        <span className="mx-1 my-0 inline-block rounded-full bg-violet-200 px-2 py-0.5 text-xs font-medium tracking-wide text-violet-700">
-          IN PROGRESS
-        </span>{" "}
-        if you have any questions or suggestions. Be concise/clear about the
-        intention of suggestions. Share progress in a leads room on{" "}
-        <Link href={DISCORD_URL} className="text-stone-500 underline">
-          Discord
-        </Link>
-        !
-      </Text>
-      <Text>
-        Move their status to
-        <span className="mx-1 my-0 inline-block rounded-full bg-red-200 px-2 py-0.5 text-xs font-medium tracking-wide text-red-700">
-          ARCHIVED
-        </span>{" "}
-        if it was made in error or any ill intent.
-      </Text>
-      <CTABlock
-        className="mt-4"
-        nodes={[
-          <>You are receiving this because you are a community manager</>,
-          <CTABlock.Button href={FIREBASE_URL}>Review {name}</CTABlock.Button>,
-        ]}
-      />
-      {recordID && (
-        <Text className="mb-0 mt-2 text-center text-xs italic text-stone-300">
-          {recordID}
+      <Layout>
+        <Logo />
+        <Text className="px-4 text-center text-3xl">
+          Pending Submission
+          <br />
+          <strong>{name}</strong>
         </Text>
-      )}
+        <Text>
+          A new member <strong className="font-semibold">{name}</strong> (
+          <Link href={`mailto:${email}`} className="text-stone-500 underline">
+            {email}
+          </Link>
+          ) submitted their information.
+        </Text>
+        <List
+          nodes={[
+            {
+              icon: "💬",
+              label: (
+                <>
+                  Check freeform fields
+                  {title && (
+                    <>
+                      , including their title &ldquo;
+                      <strong className="font-semibold">{title}</strong>
+                      &rdquo;,
+                    </>
+                  )}{" "}
+                  for misspelling and/or appropriateness.
+                  {suggestions.length > 0 && (
+                    <>
+                      {" "}
+                      They also suggested{" "}
+                      {suggestions.map((s, i) => (
+                        <span key={`suggestion-${i}`}>
+                          &ldquo;<strong className="font-semibold">{s}</strong>
+                          &rdquo;
+                          {(i < suggestions.length - 2 && ", ") ||
+                            (i === suggestions.length - 2 && " and ")}
+                        </span>
+                      ))}
+                      .
+                    </>
+                  )}
+                </>
+              ),
+            },
+            {
+              icon: "🔗",
+              label: (
+                <>
+                  Check that their URL works.{" "}
+                  <Link
+                    href={link}
+                    className="font-semibold text-inherit underline"
+                  >
+                    {link}
+                  </Link>
+                </>
+              ),
+            },
+            {
+              icon: "🌏",
+              label: (
+                <>
+                  Parse &ldquo;
+                  <strong className="font-semibold">{location}</strong>&rdquo;
+                  for the Location and indexed/searchable Region. Always try to
+                  merge, when appropriate. Seek the use of proper diacriticals,
+                  where{" "}
+                  <Link
+                    href="https://wehewehe.org"
+                    className="text-stone-500 underline"
+                  >
+                    wehewehe.org
+                  </Link>{" "}
+                  is your friend!
+                </>
+              ),
+            },
+          ]}
+        />
+        <Text>
+          Move their Status to
+          <span className="mx-1 my-0 inline-block rounded-full bg-emerald-200 px-2 py-0.5 text-xs font-medium tracking-wide text-emerald-700">
+            APPROVED
+          </span>
+          when all looks well. Then, send a welcome email to let them know
+          they&rsquo;re in!
+        </Text>
+        <Text>
+          Move their status to
+          <span className="mx-1 my-0 inline-block rounded-full bg-violet-200 px-2 py-0.5 text-xs font-medium tracking-wide text-violet-700">
+            IN PROGRESS
+          </span>{" "}
+          if you have any questions or suggestions. Be concise/clear about the
+          intention of suggestions. Share progress in a leads room on{" "}
+          <Link href={DISCORD_URL} className="text-stone-500 underline">
+            Discord
+          </Link>
+          !
+        </Text>
+        <Text>
+          Move their status to
+          <span className="mx-1 my-0 inline-block rounded-full bg-red-200 px-2 py-0.5 text-xs font-medium tracking-wide text-red-700">
+            ARCHIVED
+          </span>{" "}
+          if it was made in error or any ill intent.
+        </Text>
+        <CTABlock
+          className="mt-4"
+          nodes={[
+            <>You are receiving this because you are a community manager</>,
+            <CTABlock.Button href={FIREBASE_URL}>
+              Review {name}
+            </CTABlock.Button>,
+          ]}
+        />
+        {recordID && (
+          <Text className="mb-0 mt-2 text-center text-xs italic text-stone-300">
+            {recordID}
+          </Text>
+        )}
+      </Layout>
     </Base>
   );
 }

--- a/emails/ui/base.tsx
+++ b/emails/ui/base.tsx
@@ -32,24 +32,13 @@ export default function Base({
           </Head>
         )}
         <Body
-          className="text-stone-800 font-sans"
+          className="font-sans text-stone-800"
           style={{
             fontFamily:
               '-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
           }}
         >
-          <Container className="bg-white p-4 pt-8 rounded-xl border border-solid border-stone-200 m-4 mx-auto max-w-[540px]">
-            <Img
-              src="http://cdn.mcauto-images-production.sendgrid.net/c3cb94bafc1ef987/5ff60b90-4257-4ae9-babb-697d189b2df0/240x231.png"
-              alt="Hawaiians in Tech"
-              className={cn(
-                `w-16 mb-8`,
-                align === "center" && "mx-auto",
-                align === "right" && "ml-auto",
-              )}
-            />
-            {children}
-          </Container>
+          {children}
         </Body>
       </Tailwind>
     </Html>

--- a/emails/ui/layout.tsx
+++ b/emails/ui/layout.tsx
@@ -5,19 +5,16 @@ export default function Layout({
   children,
   border = true,
   className,
-  accentColor = "none",
 }: {
   children: React.ReactNode;
   border?: boolean;
   className?: string;
-  accentColor?: "none" | "violet";
 }) {
   return (
     <Container
       className={cn(
         "mx-auto max-w-[540px] rounded-xl p-4 pt-6",
         border && "border border-solid border-stone-200",
-        accentColor === "violet" && "border-violet-200",
         className,
       )}
     >

--- a/emails/ui/layout.tsx
+++ b/emails/ui/layout.tsx
@@ -15,7 +15,7 @@ export default function Layout({
   return (
     <Container
       className={cn(
-        "mx-auto max-w-[540px] rounded-xl p-4",
+        "mx-auto max-w-[540px] rounded-xl p-4 pt-6",
         border && "border border-solid border-stone-200",
         accentColor === "violet" && "border-violet-200",
         className,

--- a/emails/ui/layout.tsx
+++ b/emails/ui/layout.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils";
+import { Container } from "@react-email/components";
+
+export default function Layout({
+  children,
+  border = true,
+  className,
+  accentColor = "none",
+}: {
+  children: React.ReactNode;
+  border?: boolean;
+  className?: string;
+  accentColor?: "none" | "violet";
+}) {
+  return (
+    <Container
+      className={cn(
+        "mx-auto max-w-[540px] rounded-xl p-4",
+        border && "border border-solid border-stone-200",
+        accentColor === "violet" && "border-violet-200",
+        className,
+      )}
+    >
+      {children}
+    </Container>
+  );
+}

--- a/emails/ui/list.tsx
+++ b/emails/ui/list.tsx
@@ -13,7 +13,7 @@ export default function List({
     <Section className="text-xs sm:text-sm">
       {nodes?.map(({ icon, label }, i) => (
         <Row className={cn(i > 0 && i < nodes.length - 1 && "my-2")} key={i}>
-          <Column className="w-12 text-4xl">{icon}</Column>
+          <Column className="w-16 text-center text-4xl">{icon}</Column>
           <Column>{label}</Column>
         </Row>
       ))}

--- a/emails/ui/logo.tsx
+++ b/emails/ui/logo.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@/lib/utils";
+import { Img } from "@react-email/components";
+
+export default function Logo({
+  align = "center",
+}: {
+  align?: "left" | "center" | "right";
+}) {
+  return (
+    <Img
+      src="http://cdn.mcauto-images-production.sendgrid.net/c3cb94bafc1ef987/5ff60b90-4257-4ae9-babb-697d189b2df0/240x231.png"
+      alt="Hawaiians in Tech"
+      className={cn(
+        `mb-8 w-16`,
+        align === "center" && "mx-auto",
+        align === "right" && "ml-auto",
+      )}
+    />
+  );
+}

--- a/emails/ui/logo.tsx
+++ b/emails/ui/logo.tsx
@@ -8,10 +8,10 @@ export default function Logo({
 }) {
   return (
     <Img
-      src="http://cdn.mcauto-images-production.sendgrid.net/c3cb94bafc1ef987/5ff60b90-4257-4ae9-babb-697d189b2df0/240x231.png"
+      src="https://tj8xrxsxqdtxeknk.public.blob.vercel-storage.com/email/logo-hawaiiansintech-xs-FL3C71uYfwNZ41s5VriRQ2eUq9ClR6.png"
       alt="Hawaiians in Tech"
       className={cn(
-        `mb-8 w-16`,
+        `mb-4 w-20`,
         align === "center" && "mx-auto",
         align === "right" && "ml-auto",
       )}

--- a/emails/welcome-email.tsx
+++ b/emails/welcome-email.tsx
@@ -5,6 +5,8 @@ import Base from "./ui/base";
 import CTABlock from "./ui/cta-block";
 import List from "./ui/list";
 import { MemberFields } from "@/pages/api/create-member";
+import Layout from "./ui/layout";
+import Logo from "./ui/logo";
 
 export default function WelcomeEmail({
   name = "[Name Inoa]",
@@ -19,13 +21,15 @@ export default function WelcomeEmail({
       title="Welcome to Hawaiians in Tech"
       align="left"
     >
-      <Text className="px-4">
-        <span className="block text-2xl font-medium leading-loose">
-          {name}, welcome to
-        </span>
-        <strong className="text-5xl font-semibold">Hawaiians in Tech</strong>
-      </Text>
-      {VERIFICATION_LINK && (
+      <Layout>
+        <Logo align="left" />
+        <Text>
+          <span className="block text-2xl font-medium leading-loose">
+            {name}, welcome to
+          </span>
+          <strong className="text-5xl font-semibold">Hawaiians in Tech</strong>
+        </Text>
+        {/* {VERIFICATION_LINK && (
         <CTABlock
           nodes={[
             <Text className="my-0 pr-4 text-center text-xs text-stone-500">
@@ -36,116 +40,118 @@ export default function WelcomeEmail({
             </CTABlock.Button>,
           ]}
         />
-      )}
+      )} */}
 
-      <Text className="mt-5">Aloha kāua e {name},</Text>
-      <Text>
-        Mahalo nui for joining Hawaiians In Tech! We&rsquo;re excited to welcome
-        you into our hui of Native Hawaiians in technical fields and in the
-        technology industry. Together we can inspire and support each other.
-      </Text>
-      <Text>
-        A community manager should be reaching out once we review your
-        submission and get you added to the directory. Beyond that, this is a
-        pretty (intentionally) simple operation. 🤙🏼🤙🏽🤙🏾
-      </Text>
-
-      <List
-        nodes={[
-          {
-            icon: "🖥️",
-            label: (
-              <>
-                <Link
-                  className="font-bold text-inherit"
-                  href="https://hawaiiansintech.org?utm_source=confirmation-email-body"
-                >
-                  Connect with people who share an area of focus
-                </Link>
-                . Try searching for others via our Home directory, then shoot an
-                introductory DM on LinkedIn or otherwise. Mai hilahila.{" "}
-                <Link
-                  className="text-brown-500 text-inherit"
-                  href="https://hawaiiansintech.org?utm_source=confirmation-email-body"
-                >
-                  → Home
-                </Link>
-              </>
-            ),
-          },
-          {
-            icon: "💬",
-            label: (
-              <>
-                <Link
-                  className="font-bold text-inherit"
-                  href={`${DISCORD_URL}?utm_source=confirmation-email-body`}
-                >
-                  Join the discussion on our Discord server
-                </Link>
-                . Even if you&rsquo;ve never heard of it, it&rsquo;s just like
-                Slack. Our busiest channels are{" "}
-                <strong className="font-semibold text-stone-500">
-                  #opportunities
-                </strong>{" "}
-                and{" "}
-                <strong className="font-semibold text-stone-500">
-                  #events
-                </strong>
-                .{" "}
-                <Link
-                  className="font-medium text-brown-500 text-inherit"
-                  href="https://hawaiiansintech.org/discord?utm_source=confirmation-email-body"
-                >
-                  → Discord
-                </Link>
-              </>
-            ),
-          },
-          {
-            icon: "⌨️",
-            label: (
-              <>
-                <Link className="font-bold text-inherit" href={GITHUB_URL}>
-                  Contribute to our projects on GitHub
-                </Link>
-                . We welcome all ideas and moving hands on keyboards. Build
-                features; participate in code reviews; offer technical
-                mentorship and seek it out!{" "}
-                <Link
-                  className="font-medium text-brown-500 text-inherit"
-                  href={GITHUB_URL}
-                >
-                  → Github
-                </Link>
-              </>
-            ),
-          },
-        ]}
-      />
-
-      <Text className="mb-0">E ola,</Text>
-      <Text className="mt-0">The Hawaiians in Tech team</Text>
-      <Text className="my-0 text-center text-stone-500">
-        <Link
-          href="https://hawaiiansintech.org/about?utm_source=confirmation-email-footer"
-          className="text-xs text-inherit"
-        >
-          About
-        </Link>
-        <span className="mx-1">·</span>
-        <Link
-          href="https://hawaiiansintech.org/privacy-policy?utm_source=confirmation-email-footer"
-          className="text-xs text-inherit"
-        >
-          Privacy Policy
-        </Link>
-      </Text>
-      {recordID && (
-        <Text className="mb-0 mt-2 text-center text-xs italic text-stone-300">
-          {recordID}
+        <Text className="mt-5">Aloha kāua e {name},</Text>
+        <Text>
+          Mahalo nui for joining Hawaiians In Tech! We&rsquo;re excited to
+          welcome you into our hui of Native Hawaiians in technical fields and
+          in the technology industry. Together we can inspire and support each
+          other.
         </Text>
-      )}
+        <Text>
+          A community manager should be reaching out once we review your
+          submission and get you added to the directory. Beyond that, this is a
+          pretty (intentionally) simple operation. 🤙🏼🤙🏽🤙🏾
+        </Text>
+
+        <List
+          nodes={[
+            {
+              icon: "🖥️",
+              label: (
+                <>
+                  <Link
+                    className="font-bold text-inherit"
+                    href="https://hawaiiansintech.org?utm_source=confirmation-email-body"
+                  >
+                    Connect with people who share an area of focus
+                  </Link>
+                  . Try searching for others via our Home directory, then shoot
+                  an introductory DM on LinkedIn or otherwise. Mai hilahila.{" "}
+                  <Link
+                    className="text-brown-500 text-inherit"
+                    href="https://hawaiiansintech.org?utm_source=confirmation-email-body"
+                  >
+                    → Home
+                  </Link>
+                </>
+              ),
+            },
+            {
+              icon: "💬",
+              label: (
+                <>
+                  <Link
+                    className="font-bold text-inherit"
+                    href={`${DISCORD_URL}?utm_source=confirmation-email-body`}
+                  >
+                    Join the discussion on our Discord server
+                  </Link>
+                  . Even if you&rsquo;ve never heard of it, it&rsquo;s just like
+                  Slack. Our busiest channels are{" "}
+                  <strong className="font-semibold text-stone-500">
+                    #opportunities
+                  </strong>{" "}
+                  and{" "}
+                  <strong className="font-semibold text-stone-500">
+                    #events
+                  </strong>
+                  .{" "}
+                  <Link
+                    className="font-medium text-brown-500 text-inherit"
+                    href="https://hawaiiansintech.org/discord?utm_source=confirmation-email-body"
+                  >
+                    → Discord
+                  </Link>
+                </>
+              ),
+            },
+            {
+              icon: "⌨️",
+              label: (
+                <>
+                  <Link className="font-bold text-inherit" href={GITHUB_URL}>
+                    Contribute to our projects on GitHub
+                  </Link>
+                  . We welcome all ideas and moving hands on keyboards. Build
+                  features; participate in code reviews; offer technical
+                  mentorship and seek it out!{" "}
+                  <Link
+                    className="font-medium text-brown-500 text-inherit"
+                    href={GITHUB_URL}
+                  >
+                    → Github
+                  </Link>
+                </>
+              ),
+            },
+          ]}
+        />
+
+        <Text className="mb-0">E ola,</Text>
+        <Text className="mt-0">The Hawaiians in Tech team</Text>
+        <Text className="my-0 text-center text-stone-500">
+          <Link
+            href="https://hawaiiansintech.org/about?utm_source=confirmation-email-footer"
+            className="text-xs text-inherit"
+          >
+            About
+          </Link>
+          <span className="mx-1">·</span>
+          <Link
+            href="https://hawaiiansintech.org/privacy-policy?utm_source=confirmation-email-footer"
+            className="text-xs text-inherit"
+          >
+            Privacy Policy
+          </Link>
+        </Text>
+        {recordID && (
+          <Text className="mb-0 mt-2 text-center text-xs italic text-stone-300">
+            {recordID}
+          </Text>
+        )}
+      </Layout>
     </Base>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,19 +8,19 @@
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
 "@babel/helper-plugin-utils@^7.0.0":
-  version "7.24.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz#945681931a52f15ce879fd5b86ce2dae6d3d7f2a"
-  integrity sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz#a924607dd254a65695e5bd209b98b902b3b2f11a"
+  integrity sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==
 
-"@babel/helper-string-parser@^7.23.4":
+"@babel/helper-string-parser@^7.24.1":
   version "7.24.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz#f99c36d3593db9540705d0739a1f10b5e20c696e"
   integrity sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==
 
-"@babel/helper-validator-identifier@^7.22.20":
-  version "7.22.20"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz#c4ae002c61d2879e724581d96665583dbc1dc0e0"
-  integrity sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==
+"@babel/helper-validator-identifier@^7.24.5":
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz#918b1a7fa23056603506370089bd990d8720db62"
+  integrity sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==
 
 "@babel/parser@7.24.1":
   version "7.24.1"
@@ -28,24 +28,24 @@
   integrity sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==
 
 "@babel/parser@^7.0.0", "@babel/parser@^7.20.15":
-  version "7.24.4"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.24.4.tgz#234487a110d89ad5a3ed4a8a566c36b9453e8c88"
-  integrity sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.24.5.tgz#4a4d5ab4315579e5398a82dcf636ca80c3392790"
+  integrity sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==
 
 "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.5":
-  version "7.24.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.4.tgz#de795accd698007a66ba44add6cc86542aff1edd"
-  integrity sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.5.tgz#230946857c053a36ccc66e1dd03b17dd0c4ed02c"
+  integrity sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==
   dependencies:
     regenerator-runtime "^0.14.0"
 
 "@babel/types@^7.9.6":
-  version "7.24.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.24.0.tgz#3b951f435a92e7333eba05b7566fd297960ea1bf"
-  integrity sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.24.5.tgz#7661930afc638a5383eb0c4aee59b74f38db84d7"
+  integrity sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==
   dependencies:
-    "@babel/helper-string-parser" "^7.23.4"
-    "@babel/helper-validator-identifier" "^7.22.20"
+    "@babel/helper-string-parser" "^7.24.1"
+    "@babel/helper-validator-identifier" "^7.24.5"
     to-fast-properties "^2.0.0"
 
 "@emotion/is-prop-valid@^0.8.2":
@@ -246,12 +246,12 @@
     "@firebase/util" "1.9.5"
     tslib "^2.1.0"
 
-"@firebase/app-compat@0.2.30":
-  version "0.2.30"
-  resolved "https://registry.yarnpkg.com/@firebase/app-compat/-/app-compat-0.2.30.tgz#fabcc801d3ae5cd849e8e41481286f30b185feb1"
-  integrity sha512-S3FI3yx36xq5NYWXv/rqZiEnkQ89QwfGdl26iWZ9skuOGM96DYQUxs/zs7NkfAQcfpXC8f5DuUrE0Rz/0XdTEg==
+"@firebase/app-compat@0.2.32":
+  version "0.2.32"
+  resolved "https://registry.yarnpkg.com/@firebase/app-compat/-/app-compat-0.2.32.tgz#ed57d8f49a04dcc6501f07f6bd0c63d334fcd4d5"
+  integrity sha512-xxfAQKwCmpzwwdBHXT1DTnmilwSeSy6Sa1vThL0q0mq5GPHi52onkm5wl1lrOaiP0uQwQutkZBf/Wy4tDW+5WQ==
   dependencies:
-    "@firebase/app" "0.10.0"
+    "@firebase/app" "0.10.2"
     "@firebase/component" "0.6.6"
     "@firebase/logger" "0.4.1"
     "@firebase/util" "1.9.5"
@@ -267,10 +267,10 @@
   resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.9.1.tgz#38fe81383ab4985f464e7ba8c5055015849ea4e9"
   integrity sha512-nFGqTYsnDFn1oXf1tCwPAc+hQPxyvBT/QB7qDjwK+IDYThOn63nGhzdUTXxVD9Ca8gUY/e5PQMngeo0ZW/E3uQ==
 
-"@firebase/app@0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.10.0.tgz#f8fa048ed670045b5a481b7b5dcb78fcf6b0d3c7"
-  integrity sha512-bemcsqQD4teEnCM/+FiK8LFjlfoIFewMY3LOIgxa59ISlkk4zlw4ezz1iLY45yQ6ip6WDwky7cx9UruFBAn6iw==
+"@firebase/app@0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.10.2.tgz#1a8b35bbb0b40313731de128617e6d461ac11fda"
+  integrity sha512-Sk0lQYG0IRIUXkj6Ovaxu0o1E1OdC+IR+UYEYLjXuddr6YjnpFuZ69rTxVja2Ef4TpidJky9o8OoVIaXNjDJ5A==
   dependencies:
     "@firebase/component" "0.6.6"
     "@firebase/logger" "0.4.1"
@@ -278,17 +278,17 @@
     idb "7.1.1"
     tslib "^2.1.0"
 
-"@firebase/auth-compat@0.5.5":
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/@firebase/auth-compat/-/auth-compat-0.5.5.tgz#8c9a8b1d705c05d80d44d61039e25c1faeda678f"
-  integrity sha512-iAq/wCCEX4TPhZeCOmLxscHh6oZtvJ4g/FcRLynFntW3WOtrWF9/91jq+FsDSSJo9Av8MpnayCbbx+jpGSv4DQ==
+"@firebase/auth-compat@0.5.7":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-compat/-/auth-compat-0.5.7.tgz#5cfed386d95fa1f99c2b5a605801b8c63c2bc0e7"
+  integrity sha512-NcHgTsqrdZxSEElJ+TtUzPT+LELlABVgVpxHEZX1xKY6YG8OIq2PsH5bk/0nzBvYnnYy7bJsKHsiSfS46MbRZA==
   dependencies:
-    "@firebase/auth" "1.7.0"
+    "@firebase/auth" "1.7.2"
     "@firebase/auth-types" "0.12.1"
     "@firebase/component" "0.6.6"
     "@firebase/util" "1.9.5"
     tslib "^2.1.0"
-    undici "5.28.3"
+    undici "5.28.4"
 
 "@firebase/auth-interop-types@0.2.1":
   version "0.2.1"
@@ -305,16 +305,16 @@
   resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.12.1.tgz#e519c5485cd6b188259f10764d5359d6aaea8969"
   integrity sha512-B3dhiWRWf/njWosx4zdhSEoD4WHJmr4zbnBw6t20mRG/IZ4u0rWUBlMP1vFjhMstKIow1XmoGhTwD65X5ZXLjw==
 
-"@firebase/auth@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-1.7.0.tgz#73fe86aa1897c20dbf5aef9a25a0b684c6fe293a"
-  integrity sha512-xvyCR3Ivan74AwT/rQOqrYkyu4Ccz6GOFaohi1Pw3gLOpG2WIdC/phc4zdQkLJjmbGFcYNisHyqII2P/H9ZJow==
+"@firebase/auth@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-1.7.2.tgz#0d4d7f8762be5f4de3554b06e1875ec695b3d9c9"
+  integrity sha512-I8rrmhjdSYRokfCdElqm4fjJZdi7hh9NDGhXTRmcxkgUNcWoo82nZ0Ncm66MFlTdeLhNHEPzHqd38Gv6b+zpBg==
   dependencies:
     "@firebase/component" "0.6.6"
     "@firebase/logger" "0.4.1"
     "@firebase/util" "1.9.5"
     tslib "^2.1.0"
-    undici "5.28.3"
+    undici "5.28.4"
 
 "@firebase/component@0.6.4":
   version "0.6.4"
@@ -397,13 +397,13 @@
     faye-websocket "0.11.4"
     tslib "^2.1.0"
 
-"@firebase/firestore-compat@0.3.28":
-  version "0.3.28"
-  resolved "https://registry.yarnpkg.com/@firebase/firestore-compat/-/firestore-compat-0.3.28.tgz#96d1817decd7aa84e5fe9c855756b727cc7f54da"
-  integrity sha512-qaE9QYrWV0K+nh/HWf2EL/V2fPsuTZJ8K4S4e+xUOIxVulmXXwlKg4vgJgRF6r5AlABcSphKNbz/77fChgNwiQ==
+"@firebase/firestore-compat@0.3.30":
+  version "0.3.30"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore-compat/-/firestore-compat-0.3.30.tgz#843fa0437cdb7e5723b98e4703dfdfa7ad8bc02b"
+  integrity sha512-fnNvNBBdPwziYK01tY1J9zrVYAtGUOsLhpNcU1rpfcklKEUPwXfmiJoFdtNqmgk2x5RjggGpurOPAv6aoEl/PQ==
   dependencies:
     "@firebase/component" "0.6.6"
-    "@firebase/firestore" "4.5.1"
+    "@firebase/firestore" "4.6.1"
     "@firebase/firestore-types" "3.0.1"
     "@firebase/util" "1.9.5"
     tslib "^2.1.0"
@@ -413,10 +413,10 @@
   resolved "https://registry.yarnpkg.com/@firebase/firestore-types/-/firestore-types-3.0.1.tgz#5b802f8aeffe6803f594b428054b10e25a73ae66"
   integrity sha512-mVhPcHr5FICjF67m6JHgj+XRvAz/gZ62xifeGfcm00RFl6tNKfCzCfKeyB2BDIEc9dUnEstkmIXlmLIelOWoaA==
 
-"@firebase/firestore@4.5.1":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-4.5.1.tgz#7ae682172d5d833f632557a553be8e151cc08d5e"
-  integrity sha512-VQsMKJGuqlx8I+n+NhNrdFRBJU/B1O8mpGIAYABBmVxPyJax/ynuBMJkREmqzRWpbBj5IAtHe+vm4EvJlb6RLg==
+"@firebase/firestore@4.6.1":
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-4.6.1.tgz#4a788103bca46e3ee829ddb816189f23cd26212a"
+  integrity sha512-MaBOBu+QcZOp6SJzCmigiJ4Dt0HNic91w8GghbTE9L//VW/zdO7ezXrcXRK4TjWWOcazBrJZJSHTIsFdwZyvtQ==
   dependencies:
     "@firebase/component" "0.6.6"
     "@firebase/logger" "0.4.1"
@@ -425,15 +425,15 @@
     "@grpc/grpc-js" "~1.9.0"
     "@grpc/proto-loader" "^0.7.8"
     tslib "^2.1.0"
-    undici "5.28.3"
+    undici "5.28.4"
 
-"@firebase/functions-compat@0.3.9":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/@firebase/functions-compat/-/functions-compat-0.3.9.tgz#932dafd47a2dd42eac37869db216b4e92137f1be"
-  integrity sha512-yVcNBUljBFD6VPeTJcnWBEFZlVICKWuJzJmPuvgKEH++8z/CdgUKw0YslceaPQIWnstdviZDEF1cjJnR/bLvzQ==
+"@firebase/functions-compat@0.3.10":
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/@firebase/functions-compat/-/functions-compat-0.3.10.tgz#dc3a9dfa3d9821d9553cfce294722a7bba04ecd4"
+  integrity sha512-2Yidp6Dgf2k8LqJDQUTqdYFdf4ySNmZ71yeDX4lThby1HRMww+Y3nN98YaM6hHarZX3PUfaMUiMBZMHCRRT2IA==
   dependencies:
     "@firebase/component" "0.6.6"
-    "@firebase/functions" "0.11.3"
+    "@firebase/functions" "0.11.4"
     "@firebase/functions-types" "0.6.1"
     "@firebase/util" "1.9.5"
     tslib "^2.1.0"
@@ -443,10 +443,10 @@
   resolved "https://registry.yarnpkg.com/@firebase/functions-types/-/functions-types-0.6.1.tgz#4d4a57135050c0a0448b562c909807a95232b394"
   integrity sha512-DirqgTXSBzyKsQwcKnx/YdGMaRdJhywnThrINP+Iog8QfQnrL7aprTXHDFHlpZEMwykS54YRk53xzz7j396QXQ==
 
-"@firebase/functions@0.11.3":
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/@firebase/functions/-/functions-0.11.3.tgz#b3535879ed572cf9c9c0bebff8270df0b5a5798d"
-  integrity sha512-fpjc3VwxsgFBcR0wmof6kIng7NNvhjqetwWUTMs/ZeOI0QiZoUvSDaudFZvPfvXujSK/sr3tk9G1YzjbwCQkgQ==
+"@firebase/functions@0.11.4":
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/@firebase/functions/-/functions-0.11.4.tgz#0ed020be168cb306473ee99f8b61b8adc2993208"
+  integrity sha512-FeMpXtlZG8hnxUauI5J8BSmIbY/Gcv7UVlByxHuHmGxxeS8mJPuAdIxPLUBNtV/naf+MeimIPcpPMslYr6tN6w==
   dependencies:
     "@firebase/app-check-interop-types" "0.3.1"
     "@firebase/auth-interop-types" "0.2.2"
@@ -454,7 +454,7 @@
     "@firebase/messaging-interop-types" "0.2.1"
     "@firebase/util" "1.9.5"
     tslib "^2.1.0"
-    undici "5.28.3"
+    undici "5.28.4"
 
 "@firebase/installations-compat@0.2.6":
   version "0.2.6"
@@ -496,13 +496,13 @@
   dependencies:
     tslib "^2.1.0"
 
-"@firebase/messaging-compat@0.2.7":
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/@firebase/messaging-compat/-/messaging-compat-0.2.7.tgz#46d09492de50eda1539fd94f4731ee2b1dd3444c"
-  integrity sha512-29eeNzkjJPNc1RAVmxocaA8PzkbtuNvabX8jKw3N8VdAmyugx7+dYB+jCnereiWqIwivIZ2xSbCUQ24vC7+HaQ==
+"@firebase/messaging-compat@0.2.8":
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/@firebase/messaging-compat/-/messaging-compat-0.2.8.tgz#8c7778502e2bcbd313e676aa600193b16ec593fa"
+  integrity sha512-/2ibL9u64jn76g67qjAZutVnPTV6euu0z3BvCjcqlNbMMdtoyNjyHOBRe/D7eVcrRt0uB4rTPnjr3A6sVKdjuA==
   dependencies:
     "@firebase/component" "0.6.6"
-    "@firebase/messaging" "0.12.7"
+    "@firebase/messaging" "0.12.8"
     "@firebase/util" "1.9.5"
     tslib "^2.1.0"
 
@@ -511,10 +511,10 @@
   resolved "https://registry.yarnpkg.com/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.1.tgz#eea3986fa5e45a39d9de784847435dba35fc8980"
   integrity sha512-jfGJ7Jc32BDHXvXHyXi34mVLzZY8X0t929DTMwz7Tj2Hc40Zuzx8VRCIPLRrRUyvBrJCd5EpIcQgCygXhtaN1A==
 
-"@firebase/messaging@0.12.7":
-  version "0.12.7"
-  resolved "https://registry.yarnpkg.com/@firebase/messaging/-/messaging-0.12.7.tgz#977c661a64418b6086289b3707e6638f8a17df18"
-  integrity sha512-FNZiGMZWjU2D13U/XpoGDSfqCx2kqJ171P3VjquBJfd8SkYNyJMkKM82QvTjQaDd4nuWzgvTDR81DGJFUO6AOg==
+"@firebase/messaging@0.12.8":
+  version "0.12.8"
+  resolved "https://registry.yarnpkg.com/@firebase/messaging/-/messaging-0.12.8.tgz#b62377bacb656bf326407c121466fbdaa766a0fd"
+  integrity sha512-FbCTNhv5DUBo8It+Wj3XbKM1xf3PeoHsHk8PjMWBNm0yP+LL8Jhd3ejRsukEYdysTMvgxY4sU5Cs5YNTK44qTQ==
   dependencies:
     "@firebase/component" "0.6.6"
     "@firebase/installations" "0.6.6"
@@ -579,13 +579,13 @@
     "@firebase/util" "1.9.5"
     tslib "^2.1.0"
 
-"@firebase/storage-compat@0.3.6":
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/@firebase/storage-compat/-/storage-compat-0.3.6.tgz#831383055dd1e92900f999725f82e1e270416d05"
-  integrity sha512-AKv0vwktqdW4SDDDcHSN2ahi1Hpjs8rTM6sE7+yrWpm8cRght/PkqylsFnIe+a/toCNd8WeWaXq/oaXHPvRw1w==
+"@firebase/storage-compat@0.3.7":
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/@firebase/storage-compat/-/storage-compat-0.3.7.tgz#0c0b1072413ad2da9fda37de835149cb2895d2d3"
+  integrity sha512-pTlNAm8/QPN7vhYRyd5thr2ouCykP+wIFXHY1AV42WTrk98sTGdIlt/tusHzmrH4mJ34MPaICS0cn2lYikiq8w==
   dependencies:
     "@firebase/component" "0.6.6"
-    "@firebase/storage" "0.12.3"
+    "@firebase/storage" "0.12.4"
     "@firebase/storage-types" "0.8.1"
     "@firebase/util" "1.9.5"
     tslib "^2.1.0"
@@ -595,15 +595,15 @@
   resolved "https://registry.yarnpkg.com/@firebase/storage-types/-/storage-types-0.8.1.tgz#3917fc36a9c47425b923e0f7be6332601633d109"
   integrity sha512-yj0vypPT9UbbfYYwzpXPYchnjWqCADcTbGNawAIebww8rnQYPGbESYTKQdFRPXiLspYPB7xCHTXThmMJuvDcsQ==
 
-"@firebase/storage@0.12.3":
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/@firebase/storage/-/storage-0.12.3.tgz#d420989e8686f7e5d532f381261bfe1c1668a92b"
-  integrity sha512-JP/rN8fb4CgCo7k/I8OLVgRx5cgExsWOIUQ2O2VQwR6YKItuL375c9v7PDaOfEcFZea/fXtfJJ3Z2NaI9445CQ==
+"@firebase/storage@0.12.4":
+  version "0.12.4"
+  resolved "https://registry.yarnpkg.com/@firebase/storage/-/storage-0.12.4.tgz#aed3e2a57a6a60bb4625ba3a6176a764baddd925"
+  integrity sha512-HcmUcp2kSSr5cHkIqFrgUW+i20925EEjkXepQxgBcI2Vx0cyqshr8iETtGow2+cMBFeY8H2swsKKabOKAjIwlQ==
   dependencies:
     "@firebase/component" "0.6.6"
     "@firebase/util" "1.9.5"
     tslib "^2.1.0"
-    undici "5.28.3"
+    undici "5.28.4"
 
 "@firebase/util@1.9.3":
   version "1.9.3"
@@ -625,31 +625,31 @@
   integrity sha512-EnfRJvrnzkHwN3BPMCayCFT5lCqInzg3RdlRsDjDvB1EJli6Usj26T6lJ67BU2UcYXBS5xcp1Wj4+zRzj2NaZg==
 
 "@floating-ui/core@^1.0.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.0.tgz#fa41b87812a16bf123122bf945946bae3fdf7fc1"
-  integrity sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.1.tgz#a4e6fef1b069cda533cbc7a4998c083a37f37573"
+  integrity sha512-42UH54oPZHPdRHdw6BgoBD6cg/eVTmVrFcgeRDM3jbO7uxSoipVcmcIGFcA5jmOHO5apcyvBhkSKES3fQJnu7A==
   dependencies:
-    "@floating-ui/utils" "^0.2.1"
+    "@floating-ui/utils" "^0.2.0"
 
-"@floating-ui/dom@^1.6.1":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.3.tgz#954e46c1dd3ad48e49db9ada7218b0985cee75ef"
-  integrity sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==
+"@floating-ui/dom@^1.0.0":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.4.tgz#3a9d1f3b7ccdab89a4ca05713acc6204b1f67a29"
+  integrity sha512-0G8R+zOvQsAG1pg2Q99P21jiqxqGBW1iRe/iXHsBRBxnpXKFI8QwbB4x5KmYLggNO5m34IQgOIu9SCRfR/WWiQ==
   dependencies:
     "@floating-ui/core" "^1.0.0"
     "@floating-ui/utils" "^0.2.0"
 
 "@floating-ui/react-dom@^2.0.0":
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.8.tgz#afc24f9756d1b433e1fe0d047c24bd4d9cefaa5d"
-  integrity sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.9.tgz#264ba8b061000baa132b5910f0427a6acf7ad7ce"
+  integrity sha512-q0umO0+LQK4+p6aGyvzASqKbKOJcAHJ7ycE9CuUvfx3s9zTHWmGJTPOIlM/hmSBfUfg/XfY5YhLBLR/LHwShQQ==
   dependencies:
-    "@floating-ui/dom" "^1.6.1"
+    "@floating-ui/dom" "^1.0.0"
 
-"@floating-ui/utils@^0.2.0", "@floating-ui/utils@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.1.tgz#16308cea045f0fc777b6ff20a9f25474dd8293d2"
-  integrity sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==
+"@floating-ui/utils@^0.2.0":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.2.tgz#d8bae93ac8b815b2bd7a98078cf91e2724ef11e5"
+  integrity sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw==
 
 "@google-cloud/firestore@^6.8.0":
   version "6.8.0"
@@ -720,13 +720,13 @@
     "@types/node" ">=12.12.47"
 
 "@grpc/proto-loader@^0.7.0", "@grpc/proto-loader@^0.7.8":
-  version "0.7.12"
-  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.12.tgz#787b58e3e3771df30b1567c057b6ab89e3a42911"
-  integrity sha512-DCVwMxqYzpUCiDMl7hQ384FqP4T3DbNpXU8pt681l3UWCip1WUiD5JrkImUwCB9a7f2cq4CUTmi5r/xIMRPY1Q==
+  version "0.7.13"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.13.tgz#f6a44b2b7c9f7b609f5748c6eac2d420e37670cf"
+  integrity sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==
   dependencies:
     lodash.camelcase "^4.3.0"
     long "^5.0.0"
-    protobufjs "^7.2.4"
+    protobufjs "^7.2.5"
     yargs "^17.7.2"
 
 "@isaacs/cliui@^8.0.2":
@@ -782,9 +782,9 @@
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@jsdoc/salty@^0.2.1":
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/@jsdoc/salty/-/salty-0.2.7.tgz#98ddce519fd95d7bee605a658fabf6e8cbf7556d"
-  integrity sha512-mh8LbS9d4Jq84KLw8pzho7XC2q2/IJGiJss3xwRoLD1A+EE16SjN4PfaG4jRCzKegTFLlN0Zd8SdUPE6XdoPFg==
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/@jsdoc/salty/-/salty-0.2.8.tgz#8d29923a9429694a437a50ab75004b576131d597"
+  integrity sha512-5e+SFVavj1ORKlKaKr2BmTOekmXbelU7dC0cDkQLqag7xfuTPuGMUFx7KWJuv4bYZrTsoL2Z18VVCOKYxzoHcg==
   dependencies:
     lodash "^4.17.21"
 
@@ -1661,10 +1661,20 @@
   resolved "https://registry.yarnpkg.com/@react-email/body/-/body-0.0.7.tgz#f2ac3cef62c6ef5805f77e3cc3f907af3ff1e718"
   integrity sha512-vjJ5P1MUNWV0KNivaEWA6MGj/I3c764qQJMsKjCHlW6mkFJ4SXbm2OlQFtKAb++Bj8LDqBlnE6oW77bWcMc0NA==
 
+"@react-email/body@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@react-email/body/-/body-0.0.8.tgz#ab91fb4e73a7a5abd47498eeb754928252855ae9"
+  integrity sha512-gqdkNYlIaIw0OdpWu8KjIcQSIFvx7t2bZpXVxMMvBS859Ia1+1X3b5RNbjI3S1ZqLddUf7owOHkO4MiXGE+nxg==
+
 "@react-email/button@0.0.14":
   version "0.0.14"
   resolved "https://registry.yarnpkg.com/@react-email/button/-/button-0.0.14.tgz#1508a38655697db7eddd678432255c5e99eb9b61"
   integrity sha512-SMk40moGcAvkHIALX4XercQlK0PNeeEIam6OXHw68ea9WtzzqVwiK4pzLY0iiMI9B4xWHcaS2lCPf3cKbQBf1Q==
+
+"@react-email/button@0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@react-email/button/-/button-0.0.15.tgz#4cedcb02a0d545fbb3ee00135a1daf1cd5517447"
+  integrity sha512-9Zi6SO3E8PoHYDfcJTecImiHLyitYWmIRs0HE3Ogra60ZzlWP2EXu+AZqwQnhXuq+9pbgwBWNWxB5YPetNPTNA==
 
 "@react-email/code-block@0.0.3":
   version "0.0.3"
@@ -1673,17 +1683,60 @@
   dependencies:
     prismjs "1.29.0"
 
+"@react-email/code-block@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@react-email/code-block/-/code-block-0.0.4.tgz#6fb40ac8dc132c87ab29de9f2786d79e27d4df6b"
+  integrity sha512-xjVLi/9dFNJ70N7hYme+21eQWa3b9/kgp4V+FKQJkQCuIMobxPRCIGM5jKD/0Vo2OqrE5chYv/dkg/aP8a8sPg==
+  dependencies:
+    prismjs "1.29.0"
+
 "@react-email/code-inline@0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@react-email/code-inline/-/code-inline-0.0.1.tgz#b6d826630757ce2b4bcf66595daa4b29e72b3384"
   integrity sha512-SeZKTB9Q4+TUafzeUm/8tGK3dFgywUHb1od/BrAiJCo/im65aT+oJfggJLjK2jCdSsus8odcK2kReeM3/FCNTQ==
+
+"@react-email/code-inline@0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@react-email/code-inline/-/code-inline-0.0.2.tgz#37a0ea78d1cd101b258e8c21410a2bcd071f563c"
+  integrity sha512-0cmgbbibFeOJl0q04K9jJlPDuJ+SEiX/OG6m3Ko7UOkG3TqjRD8Dtvkij6jNDVfUh/zESpqJCP2CxrCLLMUjdA==
+
+"@react-email/column@0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@react-email/column/-/column-0.0.10.tgz#c29ecf6ddc8b296dd92cb169f8ba352f05527e46"
+  integrity sha512-MnP8Mnwipr0X3XtdD6jMLckb0sI5/IlS6Kl/2F6/rsSWBJy5Gg6nizlekTdkwDmy0kNSe3/1nGU0Zqo98pl63Q==
 
 "@react-email/column@0.0.9":
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/@react-email/column/-/column-0.0.9.tgz#3107f50216c0cfed0a42b0386e3ccfdac0ec12e6"
   integrity sha512-1ekqNBgmbS6m97/sUFOnVvQtLYljUWamw8Y44VId95v6SjiJ4ca+hMcdOteHWBH67xkRofEOWTvqDRea5SBV8w==
 
-"@react-email/components@0.0.16", "@react-email/components@^0.0.16":
+"@react-email/components@0.0.17":
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/@react-email/components/-/components-0.0.17.tgz#5590e3884256ccd084ef4e0eda92808328077665"
+  integrity sha512-x5gGQaK0QchbwHvUrCBVnE8GCWdO5osTVuTSA54Fwzels6ZDeNTHEYRx9gI3Nwcf/dkoVYkVH4rzWST0SF0MLA==
+  dependencies:
+    "@react-email/body" "0.0.8"
+    "@react-email/button" "0.0.15"
+    "@react-email/code-block" "0.0.4"
+    "@react-email/code-inline" "0.0.2"
+    "@react-email/column" "0.0.10"
+    "@react-email/container" "0.0.12"
+    "@react-email/font" "0.0.6"
+    "@react-email/head" "0.0.8"
+    "@react-email/heading" "0.0.12"
+    "@react-email/hr" "0.0.8"
+    "@react-email/html" "0.0.8"
+    "@react-email/img" "0.0.8"
+    "@react-email/link" "0.0.8"
+    "@react-email/markdown" "0.0.10"
+    "@react-email/preview" "0.0.9"
+    "@react-email/render" "0.0.13"
+    "@react-email/row" "0.0.8"
+    "@react-email/section" "0.0.12"
+    "@react-email/tailwind" "0.0.16"
+    "@react-email/text" "0.0.8"
+
+"@react-email/components@^0.0.16":
   version "0.0.16"
   resolved "https://registry.yarnpkg.com/@react-email/components/-/components-0.0.16.tgz#469838a488a4c1fca5b34c5354ba6eabc771cb0f"
   integrity sha512-1WATpMSH03cRvhfNjGl/Up3seZJOzN9KLzlk3Q9g/cqNhZEJ7HYxoZM4AQKAI0V3ttXzzxKv8Oj+AZQLHDiICA==
@@ -1714,15 +1767,30 @@
   resolved "https://registry.yarnpkg.com/@react-email/container/-/container-0.0.11.tgz#821d1546aaeb59765095d90de82ef5c8b92d9d6f"
   integrity sha512-jzl/EHs0ClXIRFamfH+NR/cqv4GsJJscqRhdYtnWYuRAsWpKBM1muycrrPqIVhWvWi6sFHInWTt07jX+bDc3SQ==
 
+"@react-email/container@0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@react-email/container/-/container-0.0.12.tgz#54e8c3d367bc52a20cfa4125f99a63ef2ae605e4"
+  integrity sha512-HFu8Pu5COPFfeZxSL+wKv/TV5uO/sp4zQ0XkRCdnGkj/xoq0lqOHVDL4yC2Pu6fxXF/9C3PHDA++5uEYV5WVJw==
+
 "@react-email/font@0.0.5":
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@react-email/font/-/font-0.0.5.tgz#8f991776bf2a56cc4ba23d1240ef418ac210768a"
   integrity sha512-if/qKYmH3rJ2egQJoKbV8SfKCPavu+ikUq/naT/UkCr8Q0lkk309tRA0x7fXG/WeIrmcipjMzFRGTm2TxTecDw==
 
+"@react-email/font@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@react-email/font/-/font-0.0.6.tgz#11e186206b5c585cf4bfa1a46b77833d997514d2"
+  integrity sha512-sZZFvEZ4U3vNCAZ8wXqIO3DuGJR2qE/8m2fEH+tdqwa532zGO3zW+UlCTg0b9455wkJSzEBeaWik0IkNvjXzxw==
+
 "@react-email/head@0.0.7":
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/@react-email/head/-/head-0.0.7.tgz#94c9ef200467899503c903e13d0da94b6e10a8dc"
   integrity sha512-IcXL4jc0H1qzAXJCD9ajcRFBQdbUHkjKJyiUeogpaYSVZSq6cVDWQuGaI23TA9k+pI2TFeQimogUFb3Kgeeudw==
+
+"@react-email/head@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@react-email/head/-/head-0.0.8.tgz#36981ae4b51ae216760340c7c50e27f62c5142c6"
+  integrity sha512-8/NI0gtQmLIilAe6rebK1TWw3IXHxtrR02rInkQq8yQ7zKbYbzx7Q/FhmsJgAk+uYh2Er/KhgYJ0sHZyDhfMTQ==
 
 "@react-email/heading@0.0.11":
   version "0.0.11"
@@ -1731,25 +1799,59 @@
   dependencies:
     "@radix-ui/react-slot" "1.0.2"
 
+"@react-email/heading@0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@react-email/heading/-/heading-0.0.12.tgz#e57d35901889d704b9ccc455a734546b95414582"
+  integrity sha512-eB7mpnAvDmwvQLoPuwEiPRH4fPXWe6ltz6Ptbry2BlI88F0a2k11Ghb4+sZHBqg7vVw/MKbqEgtLqr3QJ/KfCQ==
+  dependencies:
+    "@radix-ui/react-slot" "1.0.2"
+
 "@react-email/hr@0.0.7":
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/@react-email/hr/-/hr-0.0.7.tgz#ba32b8f06c969fc1ac360987e5fba0dbc2af1f45"
   integrity sha512-8suK0M/deXHt0DBSeKhSC4bnCBCBm37xk6KJh9M0/FIKlvdltQBem52YUiuqVl1XLB87Y6v6tvspn3SZ9fuxEA==
+
+"@react-email/hr@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@react-email/hr/-/hr-0.0.8.tgz#d4fb055616a47bda96ba9d5d9bba78675c663b71"
+  integrity sha512-JLVvpCg2wYKEB+n/PGCggWG9fRU5e4lxsGdpK5SDLsCL0ic3OLKSpHMfeE+ZSuw0GixAVVQN7F64PVJHQkd4MQ==
 
 "@react-email/html@0.0.7":
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/@react-email/html/-/html-0.0.7.tgz#de9b758924d37f09801623782715359fea1d9db1"
   integrity sha512-oy7OoRtoOKApVI/5Lz1OZptMKmMYJu9Xn6+lOmdBQchAuSdQtWJqxhrSj/iI/mm8HZWo6MZEQ6SFpfOuf8/P6Q==
 
+"@react-email/html@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@react-email/html/-/html-0.0.8.tgz#27ad6c1bc86eb6a4686a8c9f58ddf17aae8a149a"
+  integrity sha512-arII3wBNLpeJtwyIJXPaILm5BPKhA+nvdC1F9QkuKcOBJv2zXctn8XzPqyGqDfdplV692ulNJP7XY55YqbKp6w==
+
 "@react-email/img@0.0.7":
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/@react-email/img/-/img-0.0.7.tgz#ad6bc3c22546c917add035faa3ebdecb2a6568c8"
   integrity sha512-up9tM2/dJ24u/CFjcvioKbyGuPw1yeJg605QA7VkrygEhd0CoQEjjgumfugpJ+VJgIt4ZjT9xMVCK5QWTIWoaA==
 
+"@react-email/img@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@react-email/img/-/img-0.0.8.tgz#7151f1b380a7a138ea010ae2d6aaaef3513ed611"
+  integrity sha512-jx/rPuKo31tV18fu7P5rRqelaH5wkhg83Dq7uLwJpfqhbi4KFBGeBfD0Y3PiLPPoh+WvYf+Adv9W2ghNW8nOMQ==
+
 "@react-email/link@0.0.7":
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/@react-email/link/-/link-0.0.7.tgz#7670b5be4430f173a467423a5c79c2d0e261b70b"
   integrity sha512-hXPChT3ZMyKnUSA60BLEMD2maEgyB2A37yg5bASbLMrXmsExHi6/IS1h2XiUPLDK4KqH5KFaFxi2cdNo1JOKwA==
+
+"@react-email/link@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@react-email/link/-/link-0.0.8.tgz#0938aafd27894bbf4619e0689bef512a7eac0481"
+  integrity sha512-nVikuTi8WJHa6Baad4VuRUbUCa/7EtZ1Qy73TRejaCHn+vhetc39XGqHzKLNh+Z/JFL8Hv9g+4AgG16o2R0ogQ==
+
+"@react-email/markdown@0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@react-email/markdown/-/markdown-0.0.10.tgz#f21ad5ca18dc974888ef598764f220ad52ee0340"
+  integrity sha512-MH0xO+NJ4IuJcx9nyxbgGKAMXyudFjCZ0A2GQvuWajemW9qy2hgnJ3mW3/z5lwcenG+JPn7JyO/iZpizQ7u1tA==
+  dependencies:
+    md-to-react-email "5.0.2"
 
 "@react-email/markdown@0.0.9":
   version "0.0.9"
@@ -1763,6 +1865,11 @@
   resolved "https://registry.yarnpkg.com/@react-email/preview/-/preview-0.0.8.tgz#f09ca0525e49494450255abbd3a025df310a7bd3"
   integrity sha512-Jm0KUYBZQd2w0s2QRMQy0zfHdo3Ns+9bYSE1OybjknlvhANirjuZw9E5KfWgdzO7PyrRtB1OBOQD8//Obc4uIQ==
 
+"@react-email/preview@0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@react-email/preview/-/preview-0.0.9.tgz#c5d1b999268009b8ca11fb56ae2c7084c2f2d7f2"
+  integrity sha512-2fyAA/zzZYfYmxfyn3p2YOIU30klyA6Dq4ytyWq4nfzQWWglt5hNDE0cMhObvRtfjM9ghMSVtoELAb0MWiF/kw==
+
 "@react-email/render@0.0.12":
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/@react-email/render/-/render-0.0.12.tgz#66c3217ad2018545da2ba0537d8cfd32316e3da4"
@@ -1773,15 +1880,35 @@
     react "18.2.0"
     react-dom "18.2.0"
 
+"@react-email/render@0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@react-email/render/-/render-0.0.13.tgz#6847bc42883bfaa5d1242552a7eceefa9cdeaa49"
+  integrity sha512-lmBizrV+rQeSa3GjiL8/kPU0gENqO/wv+4xrlWANabp9UY3lTLXzy7HMRSE8YFBES9AbxP5VX1iRKuEnsoBDew==
+  dependencies:
+    html-to-text "9.0.5"
+    js-beautify "^1.14.11"
+    react "^18.2.0"
+    react-dom "^18.2.0"
+
 "@react-email/row@0.0.7":
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/@react-email/row/-/row-0.0.7.tgz#a5d2653d7f3c443654e477b42641de62362304c3"
   integrity sha512-h7pwrLVGk5CIx7Ai/oPxBgCCAGY7BEpCUQ7FCzi4+eThcs5IdjSwDPefLEkwaFS8KZc56UNwTAH92kNq5B7blg==
 
+"@react-email/row@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@react-email/row/-/row-0.0.8.tgz#1f3233ed02d7f0cfc6891ee9d42434d9b36ea907"
+  integrity sha512-JsB6pxs/ZyjYpEML3nbwJRGAerjcN/Pa/QG48XUwnT/MioDWrUuyQuefw+CwCrSUZ2P1IDrv2tUD3/E3xzcoKw==
+
 "@react-email/section@0.0.11":
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/@react-email/section/-/section-0.0.11.tgz#a20b8f8176eeed8cc455aed65e3a49fceb9a6f2f"
   integrity sha512-3bZ/DuvX1julATI7oqYza6pOtWZgLJDBaa62LFFEvYjisyN+k6lrP2KOucPsDKu2DOkUzlQgK0FOm6VQJX+C0w==
+
+"@react-email/section@0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@react-email/section/-/section-0.0.12.tgz#10e513648e0d3be5a88702a1012721a38a032caa"
+  integrity sha512-UCD/N/BeOTN4h3VZBUaFdiSem6HnpuxD1Q51TdBFnqeNqS5hBomp8LWJJ9s4gzwHWk1XPdNfLA3I/fJwulJshg==
 
 "@react-email/tailwind@0.0.15":
   version "0.0.15"
@@ -1790,15 +1917,27 @@
   dependencies:
     react "18.2.0"
 
+"@react-email/tailwind@0.0.16":
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/@react-email/tailwind/-/tailwind-0.0.16.tgz#97c8810e41a0b8e8b028b80187194607ace41aec"
+  integrity sha512-uMifPxCEHaHLhpS1kVCMGyTeEL+aMYzHT4bgj8CkgCiBoF9wNNfIVMUlHGzHUTv4ZTEPaMfZgC/Hi8RqzL/Ogw==
+  dependencies:
+    react "^18.2.0"
+
 "@react-email/text@0.0.7":
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/@react-email/text/-/text-0.0.7.tgz#5e0a93cb52c943ada389161220c6d31b55d4a28f"
   integrity sha512-eHCx0mdllGcgK9X7wiLKjNZCBRfxRVNjD3NNYRmOc3Icbl8M9JHriJIfxBuGCmGg2UAORK5P3KmaLQ8b99/pbA==
 
+"@react-email/text@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@react-email/text/-/text-0.0.8.tgz#746a7b98e449112b6e155322805472bdd4f41020"
+  integrity sha512-uvN2TNWMrfC9wv/LLmMLbbEN1GrMWZb9dBK14eYxHHAEHCeyvGb5ePZZ2MPyzO7Y5yTC+vFEnCEr76V+hWMxCQ==
+
 "@rushstack/eslint-patch@^1.3.3":
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.10.1.tgz#7ca168b6937818e9a74b47ac4e2112b2e1a024cf"
-  integrity sha512-S3Kq8e7LqxkA9s7HKLqXGTGck1uwis5vAXan3FnU5yw1Ec5hsSGnq4s/UCaSqABPOnOTg7zASLyst7+ohgWexg==
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.10.2.tgz#053f1540703faa81dea2966b768ee5581c66aeda"
+  integrity sha512-hw437iINopmQuxWPSUEvqE56NCPsiU8N4AYtfHmJFckclktzK9YQJieD3XkDCDH4OjL+C7zgPUh73R/nrcHrqw==
 
 "@selderee/plugin-htmlparser2@^0.11.0":
   version "0.11.0"
@@ -1832,9 +1971,9 @@
     "@sendgrid/helpers" "^7.7.0"
 
 "@socket.io/component-emitter@~3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
-  integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz#821f8442f4175d8f0467b9daf26e3a18e2d02af2"
+  integrity sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==
 
 "@swc/core-darwin-arm64@1.3.101":
   version "1.3.101"
@@ -1965,9 +2104,9 @@
     "@types/estree" "*"
 
 "@types/eslint@*":
-  version "8.56.7"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.56.7.tgz#c33b5b5a9cfb66881beb7b5be6c34aa3e81d3366"
-  integrity sha512-SjDvI/x3zsZnOkYZ3lCt9lOZWZLB2jIlNKz+LBgCtDurK0JZcwucxYHn1w2BJkD34dgX9Tjnak0txtq4WTggEA==
+  version "8.56.10"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.56.10.tgz#eb2370a73bf04a901eeba8f22595c7ee0f7eb58d"
+  integrity sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
@@ -1978,9 +2117,9 @@
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
 "@types/express-serve-static-core@^4.17.33":
-  version "4.17.43"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.43.tgz#10d8444be560cb789c4735aea5eac6e5af45df54"
-  integrity sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.0.tgz#3ae8ab3767d98d0b682cda063c3339e1e86ccfaa"
+  integrity sha512-bGyep3JqPCRry1wq+O5n7oiBgGWmeIJXPjXXCo8EK0u8duZGSYar7cGqd3ML2JUsLGeB7fmc06KYo9fLGWqPvQ==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -2035,33 +2174,33 @@
   dependencies:
     "@types/node" "*"
 
-"@types/linkify-it@*":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-3.0.5.tgz#1e78a3ac2428e6d7e6c05c1665c242023a4601d8"
-  integrity sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==
+"@types/linkify-it@^5":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-5.0.0.tgz#21413001973106cda1c3a9b91eedd4ccd5469d76"
+  integrity sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==
 
 "@types/lodash@^4.14.175":
-  version "4.17.0"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.0.tgz#d774355e41f372d5350a4d0714abb48194a489c3"
-  integrity sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.1.tgz#0fabfcf2f2127ef73b119d98452bd317c4a17eb8"
+  integrity sha512-X+2qazGS3jxLAIz5JDXDzglAF3KpijdhFxlf/V1+hEsOUc+HnWi81L/uv/EvGuV90WY+7mPGFCUDGfQC3Gj95Q==
 
 "@types/long@^4.0.0":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
-"@types/markdown-it@^12.2.3":
-  version "12.2.3"
-  resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-12.2.3.tgz#0d6f6e5e413f8daaa26522904597be3d6cd93b51"
-  integrity sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==
+"@types/markdown-it@^14.1.1":
+  version "14.1.1"
+  resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-14.1.1.tgz#06bafb7a4e3f77b62b1f308acf7df76687887e0b"
+  integrity sha512-4NpsnpYl2Gt1ljyBGrKMxFYAYvpqbnnkgP/i/g+NLpjEUa3obn1XJCur9YbEXKDAkaXqsR1LbDnGEJ0MmKFxfg==
   dependencies:
-    "@types/linkify-it" "*"
-    "@types/mdurl" "*"
+    "@types/linkify-it" "^5"
+    "@types/mdurl" "^2"
 
-"@types/mdurl@*":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-1.0.5.tgz#3e0d2db570e9fb6ccb2dc8fde0be1d79ac810d39"
-  integrity sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==
+"@types/mdurl@^2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-2.0.0.tgz#d43878b5b20222682163ae6f897b20447233bdfd"
+  integrity sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==
 
 "@types/mime@^1":
   version "1.3.5"
@@ -2074,9 +2213,9 @@
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/node@*", "@types/node@>=10.0.0", "@types/node@>=12.12.47", "@types/node@>=13.7.0":
-  version "20.12.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.3.tgz#d6658c2c7776c1cad93534bb45428195ed840c65"
-  integrity sha512-sD+ia2ubTeWrOu+YMF+MTAB7E+O7qsMqAbMfW7DG3K1URwhZ5hN1pLlRVGbf4wDFzSfikL05M17EyorS86jShw==
+  version "20.12.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.8.tgz#35897bf2bfe3469847ab04634636de09552e8256"
+  integrity sha512-NU0rJLJnshZWdE/097cdCBbyW1h4hEg0xpovcoAQYHl8dnEyp/NAOiE45pvc+Bd1Dt+2r94v2eGFpQJ4R7g+2w==
   dependencies:
     undici-types "~5.26.4"
 
@@ -2091,9 +2230,9 @@
   integrity sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==
 
 "@types/qs@*":
-  version "6.9.14"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.14.tgz#169e142bfe493895287bee382af6039795e9b75b"
-  integrity sha512-5khscbd3SwWMhFqylJBLQ0zIu7c1K6Vz0uBIt915BI3zV0q1nfjRQD3RqSBcPaO6PHEF4ov/t9y89fSiyThlPA==
+  version "6.9.15"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.15.tgz#adde8a060ec9c305a82de1babc1056e73bd64dce"
+  integrity sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==
 
 "@types/range-parser@*":
   version "1.2.7"
@@ -2101,16 +2240,16 @@
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
 "@types/react-dom@^18.2.0":
-  version "18.2.23"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.23.tgz#112338760f622a16d64271b408355f2f27f6302c"
-  integrity sha512-ZQ71wgGOTmDYpnav2knkjr3qXdAFu0vsk8Ci5w3pGAIdj7/kKAyn+VsQDhXsmzzzepAiI9leWMmubXz690AI/A==
+  version "18.3.0"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
+  integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
   dependencies:
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^18.2.0":
-  version "18.2.74"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.74.tgz#2d52eb80e4e7c4ea8812c89181d6d590b53f958c"
-  integrity sha512-9AEqNZZyBx8OdZpxzQlaFEVCSFUM2YXJH46yPOiOpm078k6ZLOCcuAzGum/zK8YBwY+dbahVNbHrbgrAwIRlqw==
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.1.tgz#fed43985caa834a2084d002e4771e15dfcbdbe8e"
+  integrity sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -2775,9 +2914,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001599:
-  version "1.0.30001605"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001605.tgz#ca12d7330dd8bcb784557eb9aa64f0037870d9d6"
-  integrity sha512-nXwGlFWo34uliI9z3n6Qc0wZaf7zaZWA1CPZ169La5mV3I/gem7bst0vr5XQH5TJXZIMfDeZyOrZnSlVzKxxHQ==
+  version "1.0.30001616"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001616.tgz#4342712750d35f71ebba9fcac65e2cf8870013c3"
+  integrity sha512-RHVYKov7IcdNjVHJFNY/78RdG4oGVjbayxv8u5IO74Wv7Hlq4PnJE6mo/OjFijjVFNy5ijnCt6H3IIo4t+wfEw==
 
 catharsis@^0.9.0:
   version "0.9.0"
@@ -2890,7 +3029,7 @@ clsx@2.0.0:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.0.0.tgz#12658f3fd98fafe62075595a5c30e43d18f3d00b"
   integrity sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==
 
-clsx@2.1.0, clsx@^2.0.0:
+clsx@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.0.tgz#e851283bcb5c80ee7608db18487433f7b23f77cb"
   integrity sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==
@@ -2899,6 +3038,11 @@ clsx@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
+clsx@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 cmdk@^0.2.0:
   version "0.2.1"
@@ -3093,7 +3237,7 @@ define-data-property@^1.0.1, define-data-property@^1.1.4:
     es-errors "^1.3.0"
     gopd "^1.0.1"
 
-define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
+define-properties@^1.2.0, define-properties@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.1.tgz#10781cc616eb951a80a034bafcaa7377f6af2b6c"
   integrity sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==
@@ -3209,9 +3353,9 @@ editorconfig@^1.0.4:
     semver "^7.5.3"
 
 electron-to-chromium@^1.4.668:
-  version "1.4.724"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.724.tgz#e0a86fe4d3d0e05a4d7b032549d79608078f830d"
-  integrity sha512-RTRvkmRkGhNBPPpdrgtDKvmOEYTrPlXDfc0J/Nfq5s29tEahAwhiX4mmhNzj6febWMleulxVYPh7QwCSL/EldA==
+  version "1.4.756"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.756.tgz#7b872ed8c8c5bee571be771730225d6d2a37fe45"
+  integrity sha512-RJKZ9+vEBMeiPAvKNWyZjuYyUqMndcP1f335oHqn3BEQbs2NFtVrnK5+6Xg5wSM9TknNNpWghGDUCKGYF+xWXw==
 
 email-addresses@^5.0.0:
   version "5.0.0"
@@ -3285,12 +3429,7 @@ entities@^4.2.0, entities@^4.4.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
-entities@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
-  integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
-
-es-abstract@^1.22.1, es-abstract@^1.22.3, es-abstract@^1.23.0, es-abstract@^1.23.1, es-abstract@^1.23.2:
+es-abstract@^1.22.1, es-abstract@^1.22.3, es-abstract@^1.23.0, es-abstract@^1.23.1, es-abstract@^1.23.2, es-abstract@^1.23.3:
   version "1.23.3"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.23.3.tgz#8f0c5a35cd215312573c5a27c87dfd6c881a0aa0"
   integrity sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==
@@ -3355,13 +3494,13 @@ es-errors@^1.1.0, es-errors@^1.2.1, es-errors@^1.3.0:
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
 es-iterator-helpers@^1.0.15, es-iterator-helpers@^1.0.17:
-  version "1.0.18"
-  resolved "https://registry.yarnpkg.com/es-iterator-helpers/-/es-iterator-helpers-1.0.18.tgz#4d3424f46b24df38d064af6fbbc89274e29ea69d"
-  integrity sha512-scxAJaewsahbqTYrGKJihhViaM6DDZDDoucfvzNbK0pOren1g/daDQ3IAhzn+1G14rBG7w+i5N+qul60++zlKA==
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/es-iterator-helpers/-/es-iterator-helpers-1.0.19.tgz#117003d0e5fec237b4b5c08aded722e0c6d50ca8"
+  integrity sha512-zoMwbCcH5hwUkKJkT8kDIBZSz9I6mVG//+lDCinLCGov4+r7NIy0ld8o03M0cJxl2spVf6ESYVS6/gpIfq1FFw==
   dependencies:
     call-bind "^1.0.7"
     define-properties "^1.2.1"
-    es-abstract "^1.23.0"
+    es-abstract "^1.23.3"
     es-errors "^1.3.0"
     es-set-tostringtag "^2.0.3"
     function-bind "^1.1.2"
@@ -3375,9 +3514,9 @@ es-iterator-helpers@^1.0.15, es-iterator-helpers@^1.0.17:
     safe-array-concat "^1.1.2"
 
 es-module-lexer@^1.2.1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.5.0.tgz#4878fee3789ad99e065f975fdd3c645529ff0236"
-  integrity sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.5.2.tgz#00b423304f2500ac59359cc9b6844951f372d497"
+  integrity sha512-l60ETUTmLqbVbVHv1J4/qj+M8nq7AwMzEcg3kmJDt9dCNrTk+yHcYFf/Kw75pMDwd9mPcIGCG5LcS20SxYRzFA==
 
 es-object-atoms@^1.0.0:
   version "1.0.0"
@@ -3440,7 +3579,7 @@ esbuild@0.19.11:
     "@esbuild/win32-ia32" "0.19.11"
     "@esbuild/win32-x64" "0.19.11"
 
-escalade@^3.1.1:
+escalade@^3.1.1, escalade@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.2.tgz#54076e9ab29ea5bf3d8f1ed62acffbb88272df27"
   integrity sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==
@@ -3569,9 +3708,9 @@ eslint-plugin-jsx-a11y@^6.7.1:
     object.fromentries "^2.0.7"
 
 "eslint-plugin-react-hooks@^4.5.0 || 5.0.0-canary-7118f5dd7-20230705":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
-  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"
+  integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
 
 eslint-plugin-react@^7.33.2:
   version "7.34.1"
@@ -3750,35 +3889,35 @@ firebase-admin@^11.7.0:
     "@google-cloud/storage" "^6.9.5"
 
 firebase@^10.5.0:
-  version "10.10.0"
-  resolved "https://registry.yarnpkg.com/firebase/-/firebase-10.10.0.tgz#9c558a37331491d02d3b94d60cadda31731e3379"
-  integrity sha512-iJxnCKsBTYa4BSv8cscNbwciX42BvwoePTHg7iwWevb+GyVcZFmKi9eSkg/L7Jpu9mvAFv1jdDGbIaG3xRrE+w==
+  version "10.11.1"
+  resolved "https://registry.yarnpkg.com/firebase/-/firebase-10.11.1.tgz#bb507491a28e2041aed46018faddebe1d7c76306"
+  integrity sha512-7T6FJJb4PBi6IYR1212/a0djjal6nGph9AQazobWaO75+4zeyEvBDlsofWLEawVAEN2PCp8qXvFe4pMdIB5U1w==
   dependencies:
     "@firebase/analytics" "0.10.2"
     "@firebase/analytics-compat" "0.2.8"
-    "@firebase/app" "0.10.0"
+    "@firebase/app" "0.10.2"
     "@firebase/app-check" "0.8.3"
     "@firebase/app-check-compat" "0.3.10"
-    "@firebase/app-compat" "0.2.30"
+    "@firebase/app-compat" "0.2.32"
     "@firebase/app-types" "0.9.1"
-    "@firebase/auth" "1.7.0"
-    "@firebase/auth-compat" "0.5.5"
+    "@firebase/auth" "1.7.2"
+    "@firebase/auth-compat" "0.5.7"
     "@firebase/database" "1.0.4"
     "@firebase/database-compat" "1.0.4"
-    "@firebase/firestore" "4.5.1"
-    "@firebase/firestore-compat" "0.3.28"
-    "@firebase/functions" "0.11.3"
-    "@firebase/functions-compat" "0.3.9"
+    "@firebase/firestore" "4.6.1"
+    "@firebase/firestore-compat" "0.3.30"
+    "@firebase/functions" "0.11.4"
+    "@firebase/functions-compat" "0.3.10"
     "@firebase/installations" "0.6.6"
     "@firebase/installations-compat" "0.2.6"
-    "@firebase/messaging" "0.12.7"
-    "@firebase/messaging-compat" "0.2.7"
+    "@firebase/messaging" "0.12.8"
+    "@firebase/messaging-compat" "0.2.8"
     "@firebase/performance" "0.6.6"
     "@firebase/performance-compat" "0.2.6"
     "@firebase/remote-config" "0.4.6"
     "@firebase/remote-config-compat" "0.2.6"
-    "@firebase/storage" "0.12.3"
-    "@firebase/storage-compat" "0.3.6"
+    "@firebase/storage" "0.12.4"
+    "@firebase/storage-compat" "0.3.7"
     "@firebase/util" "1.9.5"
 
 follow-redirects@^1.14.8:
@@ -3802,9 +3941,9 @@ foreground-child@^3.1.0:
     signal-exit "^4.0.1"
 
 formik@^2.2.9:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/formik/-/formik-2.4.5.tgz#f899b5b7a6f103a8fabb679823e8fafc7e0ee1b4"
-  integrity sha512-Gxlht0TD3vVdzMDHwkiNZqJ7Mvg77xQNfmBRrNtvzcHZs72TJppSTDKHpImCMJZwcWPBJ8jSQQ95GJzXFf1nAQ==
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.4.6.tgz#4da75ca80f1a827ab35b08fd98d5a76e928c9686"
+  integrity sha512-A+2EI7U7aG296q2TLGvNapDNTZp1khVt5Vk0Q/fyfSROss0V/V6+txt2aJnwEos44IxTCW/LYAi/zgWzlevj+g==
   dependencies:
     "@types/hoist-non-react-statics" "^3.3.1"
     deepmerge "^2.1.1"
@@ -4022,11 +4161,12 @@ glob@^8.0.0:
     once "^1.3.0"
 
 globalthis@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.3.tgz#5852882a52b80dc301b0660273e1ed082f0b6ccf"
-  integrity sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.4.tgz#7430ed3a975d97bfb59bcce41f5cabbafa651236"
+  integrity sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==
   dependencies:
-    define-properties "^1.1.3"
+    define-properties "^1.2.1"
+    gopd "^1.0.1"
 
 globby@^11.1.0:
   version "11.1.0"
@@ -4557,20 +4697,20 @@ js2xmlparser@^4.0.2:
     xmlcreate "^2.0.4"
 
 jsdoc@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-4.0.2.tgz#a1273beba964cf433ddf7a70c23fd02c3c60296e"
-  integrity sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-4.0.3.tgz#bfee86c6a82f6823e12b5e8be698fd99ae46c061"
+  integrity sha512-Nu7Sf35kXJ1MWDZIMAuATRQTg1iIPdzh7tqJ6jjvaU/GfDf+qi5UV8zJR3Mo+/pYFvm8mzay4+6O5EWigaQBQw==
   dependencies:
     "@babel/parser" "^7.20.15"
     "@jsdoc/salty" "^0.2.1"
-    "@types/markdown-it" "^12.2.3"
+    "@types/markdown-it" "^14.1.1"
     bluebird "^3.7.2"
     catharsis "^0.9.0"
     escape-string-regexp "^2.0.0"
     js2xmlparser "^4.0.2"
     klaw "^3.0.0"
-    markdown-it "^12.3.2"
-    markdown-it-anchor "^8.4.1"
+    markdown-it "^14.1.0"
+    markdown-it-anchor "^8.6.7"
     marked "^4.0.10"
     mkdirp "^1.0.4"
     requizzle "^0.2.3"
@@ -4725,12 +4865,12 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-linkify-it@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
-  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
+linkify-it@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.0.tgz#9ef238bfa6dc70bd8e7f9572b52d369af569b421"
+  integrity sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==
   dependencies:
-    uc.micro "^1.0.1"
+    uc.micro "^2.0.0"
 
 loader-runner@^4.2.0:
   version "4.3.0"
@@ -4813,9 +4953,9 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
     js-tokens "^3.0.0 || ^4.0.0"
 
 lru-cache@^10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.0.tgz#0bd445ca57363465900f4d1f9bd8db343a4d95c3"
-  integrity sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.2.tgz#48206bc114c1252940c41b25b41af5b545aca878"
+  integrity sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -4845,21 +4985,22 @@ lucide-react@^0.295:
   resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.295.0.tgz#4c03695a3ecac8009cea51a0a895cf99ba4b56ed"
   integrity sha512-5tQQ8V4Qn9DZscW55OOk9i5z4R0TfJiMjLEwM1P1jqtY5aPD3AnY049Zfb+fyXAa1JcUS5o26Wsl/3dfvTue6w==
 
-markdown-it-anchor@^8.4.1:
+markdown-it-anchor@^8.6.7:
   version "8.6.7"
   resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz#ee6926daf3ad1ed5e4e3968b1740eef1c6399634"
   integrity sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==
 
-markdown-it@^12.3.2:
-  version "12.3.2"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.3.2.tgz#bf92ac92283fe983fe4de8ff8abfb5ad72cd0c90"
-  integrity sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==
+markdown-it@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.1.0.tgz#3c3c5992883c633db4714ccb4d7b5935d98b7d45"
+  integrity sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==
   dependencies:
     argparse "^2.0.1"
-    entities "~2.1.0"
-    linkify-it "^3.0.1"
-    mdurl "^1.0.1"
-    uc.micro "^1.0.5"
+    entities "^4.4.0"
+    linkify-it "^5.0.0"
+    mdurl "^2.0.0"
+    punycode.js "^2.3.1"
+    uc.micro "^2.1.0"
 
 marked@7.0.4:
   version "7.0.4"
@@ -4878,10 +5019,10 @@ md-to-react-email@5.0.2:
   dependencies:
     marked "7.0.4"
 
-mdurl@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
-  integrity sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==
+mdurl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
+  integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -4964,9 +5105,9 @@ minimist@^1.2.0, minimist@^1.2.6:
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 "minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.4:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.0.4.tgz#dbce03740f50a4786ba994c1fb908844d27b038c"
-  integrity sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.0.tgz#b545f84af94e567386770159302ca113469c80b8"
+  integrity sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==
 
 mkdirp@^1.0.4:
   version "1.0.4"
@@ -5093,9 +5234,9 @@ node-releases@^2.0.14:
   integrity sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==
 
 nopt@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-7.2.0.tgz#067378c68116f602f552876194fd11f1292503d7"
-  integrity sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-7.2.1.tgz#1cac0eab9b8e97c9093338446eddd40b2c8ca1e7"
+  integrity sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==
   dependencies:
     abbrev "^2.0.0"
 
@@ -5391,9 +5532,9 @@ prettier-plugin-organize-imports@^2.3.4:
   integrity sha512-R8o23sf5iVL/U71h9SFUdhdOEPsi3nm42FD/oDYIZ2PQa4TNWWuWecxln6jlIQzpZTDMUeO1NicJP6lLn2TtRw==
 
 prettier-plugin-tailwindcss@^0.5.13:
-  version "0.5.13"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.13.tgz#ee3c1e07848c90abdd1edde36a09366327e31e26"
-  integrity sha512-2tPWHCFNC+WRjAC4SIWQNSOdcL1NNkydXim8w7TDqlZi+/ulZYz2OouAI6qMtkggnPt7lGamboj6LcTMwcCvoQ==
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.14.tgz#4482eed357d5e22eac259541c70aca5a4c7b9d5c"
+  integrity sha512-Puaz+wPUAhFp8Lo9HuciYKM2Y2XExESjeT+9NQoVFXZsPPnc9VYss2SpxdQ6vbatmt8/4+SN0oe0I1cPDABg9Q==
 
 prettier@^3.0.3:
   version "3.2.5"
@@ -5473,7 +5614,7 @@ protobufjs@7.2.4:
     "@types/node" ">=13.7.0"
     long "^5.0.0"
 
-protobufjs@^7.0.0, protobufjs@^7.2.4, protobufjs@^7.2.5:
+protobufjs@^7.0.0, protobufjs@^7.2.5:
   version "7.2.6"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.6.tgz#4a0ccd79eb292717aacf07530a07e0ed20278215"
   integrity sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==
@@ -5495,6 +5636,11 @@ pseudomap@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==
+
+punycode.js@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode.js/-/punycode.js-2.3.1.tgz#6b53e56ad75588234e79f4affa90972c7dd8cdb7"
+  integrity sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==
 
 punycode@^2.1.0:
   version "2.3.1"
@@ -5518,7 +5664,7 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-react-dom@18.2.0, react-dom@^18.2.0:
+react-dom@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
   integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
@@ -5526,10 +5672,18 @@ react-dom@18.2.0, react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-dom@^18.2.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
+  integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
+  dependencies:
+    loose-envify "^1.1.0"
+    scheduler "^0.23.2"
+
 react-email@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/react-email/-/react-email-2.1.1.tgz#eb9ea3ce11386badd5ee6606656558a061df524a"
-  integrity sha512-09oMVl/jN0/Re0bT0sEqYjyyFSCN/Tg0YmzjC9wfYpnMx02Apk40XXitySDfUBMR9EgTdr6T4lYknACqiLK3mg==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/react-email/-/react-email-2.1.2.tgz#7edd22896b9434bd6fe2d96f8db4575417522a7d"
+  integrity sha512-HBHhpzEE5es9YUoo7VSj6qy1omjwndxf3/Sb44UJm/uJ2AjmqALo2yryux0CjW9QAVfitc9rxHkLvIb9H87QQw==
   dependencies:
     "@babel/parser" "7.24.1"
     "@radix-ui/colors" "1.0.1"
@@ -5538,8 +5692,8 @@ react-email@^2.1.1:
     "@radix-ui/react-slot" "1.0.2"
     "@radix-ui/react-toggle-group" "1.0.4"
     "@radix-ui/react-tooltip" "1.0.6"
-    "@react-email/components" "0.0.16"
-    "@react-email/render" "0.0.12"
+    "@react-email/components" "0.0.17"
+    "@react-email/render" "0.0.13"
     "@swc/core" "1.3.101"
     "@types/react" "^18.2.0"
     "@types/react-dom" "^18.2.0"
@@ -5629,10 +5783,17 @@ react-style-singleton@^2.2.1:
     invariant "^2.2.4"
     tslib "^2.0.0"
 
-react@18.2.0, react@^18.2.0:
+react@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
+  dependencies:
+    loose-envify "^1.1.0"
+
+react@^18.2.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
+  integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
   dependencies:
     loose-envify "^1.1.0"
 
@@ -5791,10 +5952,10 @@ sax@~1.2.1:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
-  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+scheduler@^0.23.0, scheduler@^0.23.2:
+  version "0.23.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
+  integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
   dependencies:
     loose-envify "^1.1.0"
 
@@ -6280,9 +6441,9 @@ terser-webpack-plugin@^5.3.10:
     terser "^5.26.0"
 
 terser@^5.26.0:
-  version "5.30.3"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.30.3.tgz#f1bb68ded42408c316b548e3ec2526d7dd03f4d2"
-  integrity sha512-STdUgOUx8rLbMGO9IOwHLpCqolkDITFFQSMYYwKE1N2lY6MVSaeoi10z/EhWxRc6ybqoVmKSkhKYH/XUpl7vSA==
+  version "5.31.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.31.0.tgz#06eef86f17007dbad4593f11a574c7f5eb02c6a1"
+  integrity sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"
@@ -6436,10 +6597,10 @@ typescript@^4.5.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-uc.micro@^1.0.1, uc.micro@^1.0.5:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
-  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+uc.micro@^2.0.0, uc.micro@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
+  integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
 uglify-js@^3.7.7:
   version "3.17.4"
@@ -6466,19 +6627,19 @@ undici-types@~5.26.4:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
-undici@5.28.3:
-  version "5.28.3"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.3.tgz#a731e0eff2c3fcfd41c1169a869062be222d1e5b"
-  integrity sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==
+undici@5.28.4:
+  version "5.28.4"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.4.tgz#6b280408edb6a1a604a9b20340f45b422e373068"
+  integrity sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==
   dependencies:
     "@fastify/busboy" "^2.0.0"
 
 update-browserslist-db@^1.0.13:
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz#3c5e4f5c083661bd38ef64b6328c26ed6c8248c4"
-  integrity sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.15.tgz#60ed9f8cba4a728b7ecf7356f641a31e3a691d97"
+  integrity sha512-K9HWH62x3/EalU1U6sjSZiylm9C8tgq2mSvshZpqc7QE69RaA2qjhkW2HlNA0tFpEbtyFz7HTqbSdN4MSwUodA==
   dependencies:
-    escalade "^3.1.1"
+    escalade "^3.1.2"
     picocolors "^1.0.0"
 
 uri-js@^4.2.2:
@@ -6737,9 +6898,9 @@ yallist@^4.0.0:
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^2.3.4:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.4.1.tgz#2e57e0b5e995292c25c75d2658f0664765210eed"
-  integrity sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.4.2.tgz#7a2b30f2243a5fc299e1f14ca58d475ed4bc5362"
+  integrity sha512-B3VqDZ+JAg1nZpaEmWtTXUlBneoGx6CPM9b0TENK6aoSu5t73dItudwdgmi6tHlIZZId4dZ9skcAQ2UbcyAeVA==
 
 yargs-parser@^21.1.1:
   version "21.1.1"


### PR DESCRIPTION
Added email thatʻs going out for the May event weʻre hosting!
- Started a `hit-store` instance using [Vercelʻs Blob storage](https://vercel.com/hawaiians-projects/~/stores) for hosting images used in our emails. As long as we keep image sizes small, I cannot imagine us running out of space/bandwidth within our Hobby instance any time soon.
  - Aside: If we want to explore adding user profile images, I see this being a way of doing it!
- Changes some email components
  - A new, opinionated `Layout` container that we should wrap most emails with.
  - Tweaks to the `List` component, giving a little more space for the emojis. Found they looked bigger after gmail swapped with their images.
  - Replaced the `Logo` with new one.