### PR TITLE
Fixes auth email error and undefined error

### DIFF
--- a/lib/api-helpers/auth.ts
+++ b/lib/api-helpers/auth.ts
@@ -80,7 +80,13 @@ export async function verifyAdminOrEmailAuthToken(
 ): Promise<MemberEmail> {
   const isAdmin = await verifyAdminToken(token, false);
   const email = await getEmailById(id);
-  if (!(isAdmin || email.email === (await verifyEmailAuthToken(token)))) {
+  if (
+    !(
+      isAdmin ||
+      email.email.toLowerCase() ===
+        (await verifyEmailAuthToken(token)).toLowerCase()
+    )
+  ) {
     throw new TokenVerificationError("Not authorized to access this account");
   }
   return email;

--- a/lib/firebase-helpers/initializeAdmin.ts
+++ b/lib/firebase-helpers/initializeAdmin.ts
@@ -25,6 +25,7 @@ export const initializeAdmin = async () => {
       admin.initializeApp({
         credential: admin.credential.cert(serviceAccount),
       });
+      admin.firestore().settings({ ignoreUndefinedProperties: true });
     } catch (error) {
       throw new Error(
         "Failed to initialize Firebase Admin SDK with the " +

--- a/pages/api/emails.tsx
+++ b/pages/api/emails.tsx
@@ -26,7 +26,11 @@ async function verifyAdminOrEmailAuthToken(
 ): Promise<MemberEmail> {
   const isAdmin = await verifyAdminToken(token, false);
   const email = await getEmailById(id);
-  if (isAdmin || email.email === (await verifyEmailAuthToken(token))) {
+  if (
+    isAdmin ||
+    email.email.toLowerCase() ===
+      (await verifyEmailAuthToken(token)).toLowerCase()
+  ) {
     return email;
   }
   throw new TokenVerificationError("Not authorized to access this account");

--- a/pages/api/member-id.tsx
+++ b/pages/api/member-id.tsx
@@ -8,7 +8,9 @@ async function getMemberId({ token }: { token?: string }): Promise<string> {
   const memberEmail = await verifyEmailAuthToken(token);
   const getApprovedEmails = true;
   const emails = await getEmails(getApprovedEmails);
-  const matchingMember = emails.find((email) => email.email === memberEmail);
+  const matchingMember = emails.find(
+    (email) => email.email.toLowerCase() === memberEmail.toLowerCase(),
+  );
   if (!matchingMember) {
     throw new ItemNotFoundError(`Member with email ${memberEmail} not found`);
   }

--- a/pages/edit/index.tsx
+++ b/pages/edit/index.tsx
@@ -180,7 +180,7 @@ function EditForm({ baseUrl }) {
     signInWithEmailLink(auth, email, window.location.href)
       .then((result) => {
         const { user } = result;
-        if (user.email !== email) {
+        if (user.email.toLowerCase() !== email.toLowerCase()) {
           throw Error("Something was wrong with the information you provided.");
         } else {
           window.localStorage.removeItem("emailForSignIn");


### PR DESCRIPTION
### Changes

- Auth token email checking against saved emails as lowercased (email addresses aren't case sensitive)
- Adding ignoreUndefinedProperties 

### Context

- Firebase Auth tokens return a lowercased version of the email which causes issues for users who entered capital letters in their email like `MyEmail@some.server`. 
- Some fields for member data are no longer being used, adding ignoreUndefinedProperties to avoid undefined errors

### Notes

- verifyAdminOrEmailAuthToken should probably be refactored to one function in the future