### PR TITLE
Removes case sensitivity for emails on lookup

### DIFF
--- a/pages/api/verify-email.tsx
+++ b/pages/api/verify-email.tsx
@@ -20,7 +20,9 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse) {
   await verifyTurnstileToken(turnstileToken, ip);
   const getApprovedEmails = true;
   const emails = await getEmails(getApprovedEmails);
-  const matchingMember = emails.find((email) => email.email === req.body.email);
+  const matchingMember = emails.find(
+    (email) => email.email.toLowerCase() === req.body.email.toLowerCase(),
+  );
   if (!matchingMember) {
     throw new ItemNotFoundError(
       `Member with email ${req.body.email} not found`,


### PR DESCRIPTION
- Auth token email checking against saved emails as lowercased (email addresses aren't case sensitive)
- This should have been part of https://github.com/hawaiians/hawaiiansintech/pull/39, only affects the member edit page right now